### PR TITLE
+ transformation.py

### DIFF
--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -92,8 +92,8 @@ def extract_filenames(directory, extension='.xml'):
     :param extension: String with the extension that we are looking for, xml is the default value
     :return: A list with all the file names inside this directory, excluding extensions
     """
-    filenames = [os.path.basename(article_file).rstrip(extension) for article_file in listdir_nohidden(directory, extension) if
-                 os.path.isfile(article_file)]
+    filenames = [os.path.basename(article_file).rstrip(extension) for article_file in
+                 listdir_nohidden(directory, extension) if os.path.isfile(article_file)]
     return filenames
 
 
@@ -408,7 +408,6 @@ def compare_article_pubdate(article, days=22):
         print("Pubdate error in {}".format(article))
 
 
-
 def download_updated_xml(article_file,
                          tempdir=newarticledir,
                          vor_check=False):
@@ -443,7 +442,7 @@ def download_updated_xml(article_file,
     else:
         get_new = True
         if vor_check:
-        # make sure that update is to a VOR for uncorrected proof
+            # make sure that update is to a VOR for uncorrected proof
             get_new = False
             path_parts = ['/',
                           'article',

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -33,41 +33,17 @@ import progressbar
 import requests
 from tqdm import tqdm
 
-from plos_regex import validate_doi, validate_filename
+from plos_regex import (validate_doi, corpusdir, newarticledir)
+from transformations import (BASE_URL_API, EXT_URL_TMP, INT_URL_TMP, URL_TMP, filename_to_doi,
+                             doi_to_path)
 
 help_str = "This program downloads a zip file with all PLOS articles and checks for updates"
-
-# Main directory of article XML files
-corpusdir = 'allofplos_xml'
-
-# Temp folder for downloading and processing new articles
-newarticledir = 'new_plos_articles'
 
 # Making sure DS.Store not included as file
 ignore_func = shutil.ignore_patterns('.DS_Store')
 
 # List of uncorrected proof articles to check for updates
 uncorrected_proofs_text_list = 'uncorrected_proofs_list.txt'
-
-# URL bases for PLOS's Solr instances, that index PLOS articles
-BASE_URL_API = 'http://api.plos.org/search'
-
-# URL bases for PLOS's raw article XML
-EXT_URL_TMP = 'http://journals.plos.org/plosone/article/file?id={0}&type=manuscript'
-INT_URL_TMP = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-prod-repo?key={0}.XML'
-URL_TMP = EXT_URL_TMP
-
-BASE_URL_DOI = 'https://doi.org/'
-url_suffix = '&type=manuscript'
-INT_URL_SUFFIX = '.XML'
-prefix = '10.1371/'
-suffix_lower = '.xml'
-annotation = 'annotation'
-correction = 'correction'
-annotation_url = 'http://journals.plos.org/plosone/article/file?id=10.1371/annotation/'
-annotation_url_int = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-prod-repo?key=10.1371/annotation/'
-annotation_doi = '10.1371/annotation'
-BASE_URL_ARTICLE_LANDING_PAGE = 'http://journals.plos.org/plosone/article?id='
 
 # Some example URLs that may be useful
 EXAMPLE_VOR_URL = ('http://solr-101.soma.plos.org:8011/solr/collection1/select?'
@@ -88,121 +64,6 @@ local_zip = 'allofplos_xml.zip'
 zip_metadata = 'zip_info.txt'
 time_formatting = "%Y_%b_%d_%Hh%Mm%Ss"
 min_files_for_valid_corpus = 200000
-
-
-def filename_to_url(filename, plos_network=False):
-    """
-    For a local XML file in the corpusdir directory, transform it to the downloadable URL where its XML resides
-    Includes transform for the 'annotation' DOIs
-    Example:
-    filename_to_url('allofplos_xml/journal.pone.1000001.xml') = \
-    'http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001'
-    :param file: relative path to local XML file in the corpusdir directory
-    :param directory: defaults to corpusdir, containing article files
-    :return: online location of a PLOS article's XML
-    """
-    if correction in filename:
-        article = 'annotation/' + (filename.split('.', 4)[2])
-    else:
-        article = os.path.splitext((os.path.basename(filename)))[0]
-    doi = prefix + article
-    return doi_to_url(doi, plos_network)
-
-
-def filename_to_doi(filename):
-    """
-    For a local XML file in the corpusdir directory, transform it to the article's DOI
-    Includes transform for the 'annotation' DOIs
-    Uses regex to make sure it's a file and not a DOI
-    Example:
-    filename_to_doi('journal.pone.1000001.xml') = '10.1371/journal.pone.1000001'
-    :param article_file: relative path to local XML file in the corpusdir directory
-    :param directory: defaults to corpusdir, containing article files
-    :return: full unique identifier for a PLOS article
-    """
-    #import pdb; pdb.set_trace()
-    if correction in filename and validate_filename(filename):
-        article = 'annotation/' + (filename.split('.', 4)[2])
-        doi = prefix + article
-    elif validate_filename(filename):
-        doi = prefix + os.path.splitext((os.path.basename(filename)))[0]
-    # NOTE: A filename should never validate as a DOI, so the next elif is wrong.
-    elif validate_doi(filename):
-        doi = filename
-    return doi
-
-
-def url_to_path(url, directory=corpusdir, plos_network=False):
-    """
-    For a given PLOS URL to an XML file, return the relative path to the local XML file
-    Example:
-    url_to_path('http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001') = \
-    'allofplos_xml/journal.pone.1000001.xml'
-    :param url: online location of a PLOS article's XML
-    :param directory: defaults to corpusdir, containing article files
-    :return: relative path to local XML file in the corpusdir directory
-    """
-    annot_prefix = 'plos.correction.'
-    if url.startswith(annotation_url) or url.startswith(annotation_url_int):
-        # NOTE: REDO THIS!
-        file_ = os.path.join(directory,
-                             annot_prefix +
-                             url[url.index(annotation_doi + '/')+len(annotation_doi + '/'):].
-                             replace(url_suffix, '').
-                             replace(INT_URL_SUFFIX, '') + '.xml')
-    else:
-        file_ = os.path.join(directory,
-                             url[url.index(prefix)+len(prefix):].
-                             replace(url_suffix, '').
-                             replace(INT_URL_SUFFIX, '') + '.xml')
-    return file_
-
-
-def url_to_doi(url):
-    """
-    For a given PLOS URL to an XML file, transform it to the article's DOI
-    Example:
-    url_to_path('http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001') = \
-    '10.1371/journal.pone.1000001'
-    :param url: online location of a PLOS article's XML
-    :return: full unique identifier for a PLOS article
-    """
-    return url[url.index(prefix):].rstrip(url_suffix).rstrip(INT_URL_SUFFIX)
-
-
-def doi_to_url(doi, plos_network=False):
-    """
-    For a given PLOS DOI, return the PLOS URL to that article's XML file
-    Example:
-    doi_to_url('10.1371/journal.pone.1000001') = \
-    'http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001'
-    :param doi: full unique identifier for a PLOS article
-    :return: online location of a PLOS article's XML
-    """
-    URL_TMP = INT_URL_TMP if plos_network else EXT_URL_TMP
-    return URL_TMP.format(doi)
-
-
-def doi_to_path(doi, directory=corpusdir):
-    """
-    For a given PLOS DOI, return the relative path to that local article
-    For DOIs that contain the word 'annotation', searches online version of the article xml to extract
-    the journal name, which goes into the filename. Will print DOI if it can't find the journal name
-    Uses regex to make sure it's a DOI and not a file
-    Example:
-    doi_to_path('10.1371/journal.pone.1000001') = 'allofplos_xml/journal.pone.1000001.xml'
-    :param doi: full unique identifier for a PLOS article
-    :param directory: defaults to corpusdir, containing article files
-    :return: relative path to local XML file
-    """
-    if doi.startswith(annotation_doi) and validate_doi(doi):
-        article_file = os.path.join(directory, "plos.correction." + doi.split('/')[-1] + suffix_lower)
-    elif validate_doi(doi):
-        article_file = os.path.join(directory, doi.lstrip(prefix) + suffix_lower)
-    # NOTE: The following check is weird, a DOI should never validate as a file name.
-    elif validate_filename(doi):
-        article_file = doi
-    return article_file
 
 
 def listdir_nohidden(path, extension='.xml', include_dir=True):

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -4,9 +4,13 @@ The following RegEx pertains to the 7 main PLOS journals and the defunct PLOS Cl
 
 import re
 
-corpusdir = 'allofplos_xml/'
+# Main directory of article XML files
+corpusdir = 'allofplos_xml'
+
+# Temp folder for downloading and processing new articles
+newarticledir = 'new_plos_articles'
+
 corpusdir_regex = re.escape(corpusdir)
-newarticledir = 'new_plos_articles/'
 newarticledir_regex = re.escape(newarticledir)
 regex_match_prefix = r"^10\.1371/"
 regex_body_match = (r"((journal\.p[a-zA-Z]{3}\.[\d]{7}$)"

--- a/allofplos/samples/corpus_analysis.py
+++ b/allofplos/samples/corpus_analysis.py
@@ -16,14 +16,13 @@ import progressbar
 import random
 import requests
 
-
+from plos_regex import (validate_doi, corpusdir, newarticledir, full_doi_regex_match, validate_url, currents_doi_filter)
+from transformations import (filename_to_doi, doi_to_path, doi_to_url)
 from plos_corpus import (listdir_nohidden, check_article_type, get_article_xml, uncorrected_proofs_text_list,
-                         get_related_article_doi, download_updated_xml, get_all_solr_dois, doi_to_path,
-                         filename_to_doi, newarticledir, get_article_pubdate, doi_to_url, download_check_and_move)
-from plos_regex import (full_doi_regex_match, validate_doi, validate_filename, validate_url, currents_doi_filter)
+                         get_related_article_doi, download_updated_xml, get_all_solr_dois, get_article_pubdate,
+                         download_check_and_move)
 
 counter = collections.Counter
-corpusdir = 'allofplos_xml'
 pmcdir = "pmc_articles"
 max_invalid_files_to_print = 100
 pmcdir = 'pmc_articles'
@@ -500,6 +499,7 @@ def get_plos_journal(article_file, caps_fixed=True):
                                                      "journal-title"])
         journal = journal[0].text
     except IndexError:
+        # Need to file ticket for this
         journal_meta = get_article_xml(article_file='allofplos_xml/journal.pone.0047704.xml',
                                        tag_path_elements=["/",
                                                           "article",

--- a/allofplos/tests/unittests.py
+++ b/allofplos/tests/unittests.py
@@ -1,8 +1,9 @@
+import os
 import unittest
 
-from plos_corpus import (doi_to_path, url_to_path, filename_to_doi, url_to_doi,
-                         filename_to_url, doi_to_url, INT_URL_TMP,
-                         EXT_URL_TMP)
+from plos_corpus import INT_URL_TMP, EXT_URL_TMP
+from transformations import (doi_to_path, url_to_path, filename_to_doi, url_to_doi,
+                            filename_to_url, doi_to_url)
 
 
 suffix = '.xml'
@@ -18,7 +19,7 @@ example_url2 = 'http://journals.plos.org/plosone/article/file?id=10.1371/'\
 example_url2_int = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-'\
                    'prod-repo?key=10.1371/annotation/3155a3e9-5fbe-435c-a'\
                    '07a-e9a4846ec0b6.XML'
-example_file2 = 'journal.ppat.correction.e92d19e0-996a-4bfa-afdd-20dce770ed75.xml'
+example_file2 = 'plos.correction.3155a3e9-5fbe-435c-a07a-e9a4846ec0b6.xml'
 example_doi2 = '10.1371/annotation/3155a3e9-5fbe-435c-a07a-e9a4846ec0b6'
 
 
@@ -28,7 +29,7 @@ class TestDOIMethods(unittest.TestCase):
         """
         TODO: What this tests are about!
         """
-        self.assertEqual(example_file, doi_to_path(example_doi), "{0} does not transform to {1}".format(example_doi, example_file))
+        self.assertEqual(os.path.join(corpusdir,example_file), doi_to_path(example_doi), "{0} does not transform to {1}".format(example_doi, example_file))
         self.assertEqual(example_file2, doi_to_path(example_doi2, ''), "{0} does not transform to {1}".format(example_doi2, example_file2))
         self.assertEqual(example_url2, doi_to_url(example_doi2), "{0} does not transform to {1}".format(example_doi2, example_url2))
         self.assertEqual(example_url, doi_to_url(example_doi), "In doi_to_url, {0} does not transform to {1}".format(example_doi, example_url))

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -1,0 +1,141 @@
+""" Includes all global variables
+"""
+
+import os
+
+from plos_regex import validate_filename, validate_doi, corpusdir
+
+# URL bases for PLOS's Solr instances, that index PLOS articles
+BASE_URL_API = 'http://api.plos.org/search'
+
+# URL bases for PLOS's raw article XML
+EXT_URL_TMP = 'http://journals.plos.org/plosone/article/file?id={0}&type=manuscript'
+INT_URL_TMP = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-prod-repo?key={0}.XML'
+URL_TMP = EXT_URL_TMP
+
+BASE_URL_DOI = 'https://doi.org/'
+url_suffix = '&type=manuscript'
+INT_URL_SUFFIX = '.XML'
+prefix = '10.1371/'
+suffix_lower = '.xml'
+annotation = 'annotation'
+correction = 'correction'
+annotation_url = 'http://journals.plos.org/plosone/article/file?id=10.1371/annotation/'
+annotation_url_int = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-prod-repo?key=10.1371/annotation/'
+annotation_doi = '10.1371/annotation'
+BASE_URL_ARTICLE_LANDING_PAGE = 'http://journals.plos.org/plosone/article?id='
+
+
+def filename_to_url(filename, plos_network=False):
+    """
+    For a local XML file in the corpusdir directory, transform it to the downloadable URL where its XML resides
+    Includes transform for the 'annotation' DOIs
+    Example:
+    filename_to_url('allofplos_xml/journal.pone.1000001.xml') = \
+    'http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001'
+    :param file: relative path to local XML file in the corpusdir directory
+    :param directory: defaults to corpusdir, containing article files
+    :return: online location of a PLOS article's XML
+    """
+    if correction in filename:
+        article = 'annotation/' + (filename.split('.', 4)[2])
+    else:
+        article = os.path.splitext((os.path.basename(filename)))[0]
+    doi = prefix + article
+    return doi_to_url(doi, plos_network)
+
+
+def filename_to_doi(filename):
+    """
+    For a local XML file in the corpusdir directory, transform it to the article's DOI
+    Includes transform for the 'annotation' DOIs
+    Uses regex to make sure it's a file and not a DOI
+    Example:
+    filename_to_doi('journal.pone.1000001.xml') = '10.1371/journal.pone.1000001'
+    :param article_file: relative path to local XML file in the corpusdir directory
+    :param directory: defaults to corpusdir, containing article files
+    :return: full unique identifier for a PLOS article
+    """
+    #import pdb; pdb.set_trace()
+    if correction in filename and validate_filename(filename):
+        article = 'annotation/' + (filename.split('.', 4)[2])
+        doi = prefix + article
+    elif validate_filename(filename):
+        doi = prefix + os.path.splitext((os.path.basename(filename)))[0]
+    # NOTE: A filename should never validate as a DOI, so the next elif is wrong.
+    elif validate_doi(filename):
+        doi = filename
+    return doi
+
+
+def url_to_path(url, directory=corpusdir, plos_network=False):
+    """
+    For a given PLOS URL to an XML file, return the relative path to the local XML file
+    Example:
+    url_to_path('http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001') = \
+    'allofplos_xml/journal.pone.1000001.xml'
+    :param url: online location of a PLOS article's XML
+    :param directory: defaults to corpusdir, containing article files
+    :return: relative path to local XML file in the corpusdir directory
+    """
+    annot_prefix = 'plos.correction.'
+    if url.startswith(annotation_url) or url.startswith(annotation_url_int):
+        # NOTE: REDO THIS!
+        file_ = os.path.join(directory,
+                             annot_prefix +
+                             url[url.index(annotation_doi + '/')+len(annotation_doi + '/'):].
+                             replace(url_suffix, '').
+                             replace(INT_URL_SUFFIX, '') + '.xml')
+    else:
+        file_ = os.path.join(directory,
+                             url[url.index(prefix)+len(prefix):].
+                             replace(url_suffix, '').
+                             replace(INT_URL_SUFFIX, '') + '.xml')
+    return file_
+
+
+def url_to_doi(url):
+    """
+    For a given PLOS URL to an XML file, transform it to the article's DOI
+    Example:
+    url_to_path('http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001') = \
+    '10.1371/journal.pone.1000001'
+    :param url: online location of a PLOS article's XML
+    :return: full unique identifier for a PLOS article
+    """
+    return url[url.index(prefix):].rstrip(url_suffix).rstrip(INT_URL_SUFFIX)
+
+
+def doi_to_url(doi, plos_network=False):
+    """
+    For a given PLOS DOI, return the PLOS URL to that article's XML file
+    Example:
+    doi_to_url('10.1371/journal.pone.1000001') = \
+    'http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001'
+    :param doi: full unique identifier for a PLOS article
+    :return: online location of a PLOS article's XML
+    """
+    URL_TMP = INT_URL_TMP if plos_network else EXT_URL_TMP
+    return URL_TMP.format(doi)
+
+
+def doi_to_path(doi, directory=corpusdir):
+    """
+    For a given PLOS DOI, return the relative path to that local article
+    For DOIs that contain the word 'annotation', searches online version of the article xml to extract
+    the journal name, which goes into the filename. Will print DOI if it can't find the journal name
+    Uses regex to make sure it's a DOI and not a file
+    Example:
+    doi_to_path('10.1371/journal.pone.1000001') = 'allofplos_xml/journal.pone.1000001.xml'
+    :param doi: full unique identifier for a PLOS article
+    :param directory: defaults to corpusdir, containing article files
+    :return: relative path to local XML file
+    """
+    if doi.startswith(annotation_doi) and validate_doi(doi):
+        article_file = os.path.join(directory, "plos.correction." + doi.split('/')[-1] + suffix_lower)
+    elif validate_doi(doi):
+        article_file = os.path.join(directory, doi.lstrip(prefix) + suffix_lower)
+    # NOTE: The following check is weird, a DOI should never validate as a file name.
+    elif validate_filename(doi):
+        article_file = doi
+    return article_file

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='allofplos',
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.8.3',
+    version='0.8.4',
     description='Get and analyze all PLOS articles',
     long_description=long_description,
     url='https://github.com/PLOS/allofplos',


### PR DESCRIPTION
In preparation for the new article class, some cleanup:
- moving transformation functions over to a new document, transformations.py
- deleting duplicate definitions of corpusdir, newarticledir; moving those to plos_regex.py
- updating import statements for new file structure
`python plos_corpus.py --plos` working as expected.