### PR TITLE
use absolute imports so library works in other directories

### DIFF
--- a/allofplos/__init__.py
+++ b/allofplos/__init__.py
@@ -1,0 +1,1 @@
+from allofplos.article_class import Article

--- a/allofplos/allofplos_basics.ipynb
+++ b/allofplos/allofplos_basics.ipynb
@@ -24,11 +24,11 @@
    "outputs": [],
    "source": [
     "import datetime\n",
-    "from plos_corpus import (get_uncorrected_proofs_list, check_if_uncorrected_proof, download_updated_xml)\n",
-    "from plos_regex import (validate_doi, show_invalid_dois, find_valid_dois)\n",
-    "from samples.corpus_analysis import (get_random_list_of_dois, check_if_doi_resolves,\n",
+    "from allofplos.plos_corpus import (get_uncorrected_proofs_list, check_if_uncorrected_proof, download_updated_xml)\n",
+    "from allofplos.plos_regex import (validate_doi, show_invalid_dois, find_valid_dois)\n",
+    "from allofplos.samples.corpus_analysis import (get_random_list_of_dois, check_if_doi_resolves,\n",
     "                                     get_all_local_dois, get_all_solr_dois, get_all_plos_dois)\n",
-    "from article_class import Article"
+    "from allofplos.article_class import Article"
    ]
   },
   {

--- a/allofplos/allofplos_basics.ipynb
+++ b/allofplos/allofplos_basics.ipynb
@@ -28,7 +28,7 @@
     "from allofplos.plos_regex import (validate_doi, show_invalid_dois, find_valid_dois)\n",
     "from allofplos.samples.corpus_analysis import (get_random_list_of_dois, check_if_doi_resolves,\n",
     "                                     get_all_local_dois, get_all_solr_dois, get_all_plos_dois)\n",
-    "from allofplos.article_class import Article"
+    "from allofplos import Article"
    ]
   },
   {

--- a/allofplos/article_class.py
+++ b/allofplos/article_class.py
@@ -12,11 +12,11 @@ from allofplos.article_elements import (parse_article_date, get_contrib_info,
                               match_contribs_to_dicts)
 
 
-class Article(object):
+class Article():
     """The primary object of a PLOS article, initialized by a valid PLOS DOI.
 
     """
-    def __init__(self, doi=None, directory=None, plos_network=False):
+    def __init__(self, doi, directory=None, plos_network=False):
         """Creation of an article object.
 
         Usage:
@@ -99,7 +99,7 @@ class Article(object):
         Using regular expressions, make sure the doi is valid before
         instantiating the article object.
         """
-        if d is not None and validate_doi(d) is False:
+        if validate_doi(d) is False:
             raise Exception("Invalid format for PLOS DOI")
         self.reset_memoized_attrs()
         self._doi = d

--- a/allofplos/article_class.py
+++ b/allofplos/article_class.py
@@ -5,18 +5,18 @@ import subprocess
 import lxml.etree as et
 import requests
 
-from transformations import (filename_to_doi, EXT_URL_TMP, INT_URL_TMP,
+from allofplos.transformations import (filename_to_doi, EXT_URL_TMP, INT_URL_TMP,
                              BASE_URL_ARTICLE_LANDING_PAGE)
-from plos_regex import (validate_doi, corpusdir)
-from article_elements import (parse_article_date, get_contrib_info,
+from allofplos.plos_regex import (validate_doi, corpusdir)
+from allofplos.article_elements import (parse_article_date, get_contrib_info,
                               match_contribs_to_dicts)
 
 
-class Article():
+class Article(object):
     """The primary object of a PLOS article, initialized by a valid PLOS DOI.
 
     """
-    def __init__(self, doi, directory=None, plos_network=False):
+    def __init__(self, doi=None, directory=None, plos_network=False):
         """Creation of an article object.
 
         Usage:
@@ -99,7 +99,7 @@ class Article():
         Using regular expressions, make sure the doi is valid before
         instantiating the article object.
         """
-        if validate_doi(d) is False:
+        if d is not None and validate_doi(d) is False:
             raise Exception("Invalid format for PLOS DOI")
         self.reset_memoized_attrs()
         self._doi = d

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -33,8 +33,8 @@ import progressbar
 import requests
 from tqdm import tqdm
 
-from plos_regex import (validate_doi, corpusdir, newarticledir)
-from transformations import (BASE_URL_API, EXT_URL_TMP, INT_URL_TMP, URL_TMP, filename_to_doi,
+from allofplos.plos_regex import (validate_doi, corpusdir, newarticledir)
+from allofplos.transformations import (BASE_URL_API, EXT_URL_TMP, INT_URL_TMP, URL_TMP, filename_to_doi,
                              doi_to_path)
 
 help_str = "This program downloads a zip file with all PLOS articles and checks for updates"

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -8,8 +8,8 @@ import os
 import allofplos
 
 # Main directory of article XML files
-ALLOFPLOS_DIR = os.path.abspath(os.path.dirname(allofplos.__file__))
-corpusdir = os.path.join(ALLOFPLOS_DIR, 'allofplos_xml')
+ALLOFPLOS_DIR_PATH = os.path.abspath(os.path.dirname(allofplos.__file__))
+corpusdir = os.path.join(ALLOFPLOS_DIR_PATH, 'allofplos_xml')
 
 # Temp folder for downloading and processing new articles
 newarticledir = 'new_plos_articles'

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -5,10 +5,8 @@ The following RegEx pertains to the 7 main PLOS journals and the defunct PLOS Cl
 import re
 import os
 
-import allofplos
-
 # Main directory of article XML files
-ALLOFPLOS_DIR_PATH = os.path.abspath(os.path.dirname(allofplos.__file__))
+ALLOFPLOS_DIR_PATH = os.path.abspath(os.path.dirname(__file__))
 corpusdir = os.path.join(ALLOFPLOS_DIR_PATH, 'allofplos_xml')
 
 # Temp folder for downloading and processing new articles

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -6,6 +6,10 @@ import re
 import os
 
 # Main directory of article XML files
+# Note: This relies on the __file__ of the plos_regex.py file. If this file is 
+# ever moved, you need to change how you define ALLOFPLOS_DIR_PATH.
+# The other approach would be to import allofplos and use allofplos.__file__ 
+# but that has a potential to introduce a circular dependency. 
 ALLOFPLOS_DIR_PATH = os.path.abspath(os.path.dirname(__file__))
 corpusdir = os.path.join(ALLOFPLOS_DIR_PATH, 'allofplos_xml')
 

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -3,9 +3,13 @@ The following RegEx pertains to the 7 main PLOS journals and the defunct PLOS Cl
 """
 
 import re
+import os
+
+import allofplos
 
 # Main directory of article XML files
-corpusdir = 'allofplos_xml'
+ALLOFPLOS_DIR = os.path.abspath(os.path.dirname(allofplos.__file__))
+corpusdir = os.path.join(ALLOFPLOS_DIR, 'allofplos_xml')
 
 # Temp folder for downloading and processing new articles
 newarticledir = 'new_plos_articles'

--- a/allofplos/samples/corpus_analysis.py
+++ b/allofplos/samples/corpus_analysis.py
@@ -16,9 +16,9 @@ import progressbar
 import random
 import requests
 
-from plos_regex import (validate_doi, corpusdir, newarticledir, full_doi_regex_match, validate_url, currents_doi_filter)
-from transformations import (filename_to_doi, doi_to_path, doi_to_url)
-from plos_corpus import (listdir_nohidden, check_article_type, get_article_xml, uncorrected_proofs_text_list,
+from allofplos.plos_regex import (validate_doi, corpusdir, newarticledir, full_doi_regex_match, validate_url, currents_doi_filter)
+from allofplos.transformations import (filename_to_doi, doi_to_path, doi_to_url)
+from allofplos.plos_corpus import (listdir_nohidden, check_article_type, get_article_xml, uncorrected_proofs_text_list,
                          get_related_article_doi, download_updated_xml, get_all_solr_dois, get_article_pubdate,
                          download_check_and_move)
 

--- a/allofplos/tests/unittests.py
+++ b/allofplos/tests/unittests.py
@@ -2,14 +2,14 @@ import datetime
 import os
 import unittest
 
-from article_class import Article
-from plos_corpus import INT_URL_TMP, EXT_URL_TMP
-from transformations import (doi_to_path, url_to_path, filename_to_doi, url_to_doi,
+from allofplos.article_class import Article
+from allofplos.plos_corpus import INT_URL_TMP, EXT_URL_TMP
+from allofplos.transformations import (doi_to_path, url_to_path, filename_to_doi, url_to_doi,
                              filename_to_url, doi_to_url)
+from allofplos.plos_regex import corpusdir
 
 
 suffix = '.xml'
-corpusdir = 'allofplos_xml/'
 example_url = 'http://journals.plos.org/plosone/article/file?id=10.1371/'\
               'journal.pbio.2001413&type=manuscript'
 example_url_int = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-prod-'\

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -3,7 +3,7 @@
 
 import os
 
-from plos_regex import validate_filename, validate_doi, corpusdir
+from allofplos.plos_regex import validate_filename, validate_doi, corpusdir
 
 # URL bases for PLOS's Solr instances, that index PLOS articles
 BASE_URL_API = 'http://api.plos.org/search'


### PR DESCRIPTION
relative imports would be better but would require changing the way the scripts are run, as they then can't be treated as packages/modules in the same way.

You can't be importing modules directly unless you are in that directory, that's a suboptimal usage pattern. 

This should also close #34 and #33.