### PR TITLE
Progressbar2 -> tqdm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Using pip:
 
 ``(allofplos)$ pip install allofplos``
 
-This should install *allofplos* and requirements. At this stage your are ready to go.
+This should install *allofplos* and requirements. At this stage you are ready to go.
 
 If you want to manually install from source (for example for development purposes), first clone the proyect repository:
 
@@ -113,4 +113,4 @@ Community guidelines
 
 If you wish to contribute to this project please open a ticket in the
 GitHub repo at https://github.com/PLOS/allofplos/issues. For support
-requests write to eseiver@plos.org
+requests write to mining@plos.org

--- a/allofplos/citation_utilities.py
+++ b/allofplos/citation_utilities.py
@@ -39,6 +39,8 @@ import json
 import re
 from multiprocessing import Pool
 
+from tqdm import tqdm
+
 
 def soupify(filename):
     '''Opens the given XML file, parses it using Beautiful Soup, and returns the output.'''
@@ -472,7 +474,7 @@ def citation_database(papers, verbose=True):
 
     database = {}
 
-    for i, paper in enumerate(papers):
+    for i, paper in enumerate(tqdm(papers)):
         if verbose:
             paper_doi = plos_paper_doi(paper)
             print("DOI of paper " + str(i + 1) + " is " + paper_doi)

--- a/allofplos/makedb.py
+++ b/allofplos/makedb.py
@@ -10,8 +10,9 @@ import datetime
 import os
 import random
 
+from tqdm import tqdm
 import sqlite3
-import progressbar
+
 from peewee import Model, CharField, ForeignKeyField, TextField, \
     DateTimeField, BooleanField, IntegerField, IntegrityError
 from playhouse.sqlite_ext import SqliteExtDatabase
@@ -108,8 +109,7 @@ if args.random:
 else:
     max_value = len(allfiles)
 
-bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
-for i, file_ in enumerate(randomfiles if args.random else allfiles):
+for i, file_ in enumerate(tqdm(randomfiles if args.random else allfiles)):
     doi = filename_to_doi(file_)
     article = Article(doi)
     journal_name = journal_title_dict[article.journal.upper()]
@@ -185,5 +185,3 @@ for i, file_ in enumerate(randomfiles if args.random else allfiles):
                     corr_author = co_author,
                     article = p_art
                 )
-    bar.update(i+1)
-bar.finish()

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -371,7 +371,7 @@ def download_amended_articles(directory=corpusdir, tempdir=newarticledir, amende
         amended_article_list = check_for_amended_articles(directory)
         print(amended_article_list)
     amended_updated_article_list = []
-    print("Checking amended articles")
+    print("Checking amended articles...")
     for article in tqdm(amended_article_list):
         updated = download_updated_xml(article)
         if updated:
@@ -546,7 +546,8 @@ def remote_proofs_direct_check(tempdir=newarticledir, article_list=None, plos_ne
     proofs_download_list = []
     if article_list is None:
         article_list = get_uncorrected_proofs_list()
-    for doi in list(set(article_list)):
+    print("Checking directly for additional VOR updates...")
+    for doi in tqdm(list(set(article_list))):
         file = doi_to_path(doi)
         updated = download_updated_xml(file, vor_check=True)
         if updated:
@@ -800,6 +801,7 @@ def main():
         # Returns specific URL query & the number of search results.
         # Parses the returned dictionary of article DOIs, removing common leading numbers, as a list.
         # Compares to list of existing articles in the PLOS corpus folder to create list of DOIs to download.
+    print("Checking for new articles...")
     dois_needed_list = get_dois_needed_list()
 
     # Step 2: Download new articles

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -502,7 +502,7 @@ def download_vor_updates(directory=corpusdir, tempdir=newarticledir,
         vor_updates_available = check_for_vor_updates()
     vor_updated_article_list = []
     if vor_updates_available:
-        for article in vor_updates_available:
+        for article in tqdm(vor_updates_available):
             updated = download_updated_xml(article, vor_check=True)
             if updated:
                 vor_updated_article_list.append(article)

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -229,16 +229,19 @@ def repo_download(dois, tempdir, ignore_existing=True, plos_network=False):
         existing_articles = [filename_to_doi(file) for file in listdir_nohidden(tempdir)]
         dois = set(dois) - set(existing_articles)
 
-    for doi in tqdm(sorted(dois)):
-        url = URL_TMP.format(doi)
-        articleXML = et.parse(url)
-        article_path = doi_to_path(doi, directory=tempdir)
-        # create new local XML files
-        if ignore_existing is False or ignore_existing and os.path.isfile(article_path) is False:
-            with open(article_path, 'w') as file:
-                file.write(et.tostring(articleXML, method='xml', encoding='unicode'))
-            if not plos_network:
-                time.sleep(1)
+    if dois:
+        for doi in tqdm(sorted(dois)):
+            url = URL_TMP.format(doi)
+            articleXML = et.parse(url)
+            article_path = doi_to_path(doi, directory=tempdir)
+            # create new local XML files
+            if ignore_existing is False or ignore_existing and os.path.isfile(article_path) is False:
+                with open(article_path, 'w') as file:
+                    file.write(et.tostring(articleXML, method='xml', encoding='unicode'))
+                if not plos_network:
+                    time.sleep(1)
+    else:
+        pass
     print(len(listdir_nohidden(tempdir)), "new articles downloaded.")
     logging.info(len(listdir_nohidden(tempdir)))
 
@@ -369,13 +372,15 @@ def download_amended_articles(directory=corpusdir, tempdir=newarticledir, amende
     """
     if amended_article_list is None:
         amended_article_list = check_for_amended_articles(directory)
-        print(amended_article_list)
     amended_updated_article_list = []
     print("Checking amended articles...")
-    for article in tqdm(amended_article_list):
-        updated = download_updated_xml(article)
-        if updated:
-            amended_updated_article_list.append(article)
+    if amended_article_list:
+        for article in tqdm(amended_article_list):
+            updated = download_updated_xml(article)
+            if updated:
+                amended_updated_article_list.append(article)
+    else:
+        pass
     print(len(amended_updated_article_list), 'amended articles downloaded with new xml.')
     return amended_updated_article_list
 

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -30,7 +30,6 @@ import tarfile
 import zipfile
 
 import lxml.etree as et
-import progressbar
 import requests
 from tqdm import tqdm
 
@@ -230,9 +229,7 @@ def repo_download(dois, tempdir, ignore_existing=True, plos_network=False):
         existing_articles = [filename_to_doi(file) for file in listdir_nohidden(tempdir)]
         dois = set(dois) - set(existing_articles)
 
-    max_value = len(dois)
-    bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
-    for i, doi in enumerate(sorted(dois)):
+    for doi in tqdm(sorted(dois)):
         url = URL_TMP.format(doi)
         articleXML = et.parse(url)
         article_path = doi_to_path(doi, directory=tempdir)
@@ -242,8 +239,6 @@ def repo_download(dois, tempdir, ignore_existing=True, plos_network=False):
                 file.write(et.tostring(articleXML, method='xml', encoding='unicode'))
             if not plos_network:
                 time.sleep(1)
-        bar.update(i+1)
-    bar.finish()
     print(len(listdir_nohidden(tempdir)), "new articles downloaded.")
     logging.info(len(listdir_nohidden(tempdir)))
 
@@ -377,14 +372,10 @@ def download_amended_articles(directory=corpusdir, tempdir=newarticledir, amende
         print(amended_article_list)
     amended_updated_article_list = []
     print("Checking amended articles")
-    max_value = len(amended_article_list)
-    bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
-    for i, article in enumerate(amended_article_list):
+    for article in tqdm(amended_article_list):
         updated = download_updated_xml(article)
         if updated:
             amended_updated_article_list.append(article)
-        bar.update(i+1)
-    bar.finish()
     print(len(amended_updated_article_list), 'amended articles downloaded with new xml.')
     return amended_updated_article_list
 
@@ -402,22 +393,15 @@ def get_uncorrected_proofs_list():
         print("Creating new text list of uncorrected proofs from scratch.")
         article_files = listdir_nohidden(corpusdir)
         uncorrected_proofs_list = []
-        max_value = len(article_files)
-        bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
-        for i, article_file in enumerate(article_files):
-            bar.update(i+1)
+        for article_file in tqdm(article_files):
             article = Article.from_filename(article_file)
             if article.proof == 'uncorrected-proof':
                 uncorrected_proofs_list.append(article.doi)
-        bar.finish()
         print("Saving uncorrected proofs.")
         with open(uncorrected_proofs_text_list, 'w') as file:
             max_value = len(uncorrected_proofs_list)
-            bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
-            for i, item in enumerate(sorted(uncorrected_proofs_list)):
+            for item in tqdm(sorted(uncorrected_proofs_list)):
                 file.write("%s\n" % item)
-                bar.update(i+1)
-            bar.finish()
     return uncorrected_proofs_list
 
 

--- a/allofplos/samples/corpus_analysis.py
+++ b/allofplos/samples/corpus_analysis.py
@@ -95,7 +95,7 @@ def get_jats_article_type_list(article_list=None, directory=corpusdir):
 
     jats_article_type_list = []
 
-    for article_file in article_list:
+    for article_file in tqdm(article_list):
         article = Article.from_filename(article_file, directory=directory)
         jats_article_type_list.append(article.type_)
 
@@ -118,7 +118,7 @@ def get_plos_article_type_list(article_list=None, directory=corpusdir):
 
     PLOS_article_type_list = []
 
-    for article_file in article_list:
+    for article_file in tqdm(article_list):
         article = Article.from_filename(article_file, directory=directory)
         PLOS_article_type_list.append(article.plostype)
 
@@ -173,7 +173,7 @@ def get_retracted_doi_list(article_list=None, directory=corpusdir):
     retracted_doi_list = []
     if article_list is None:
         article_list = listdir_nohidden(directory)
-    for art in article_list:
+    for art in tqdm(article_list):
         article = Article.from_filename(art)
         article.directory = directory
         if article.type_ == 'retraction':
@@ -202,7 +202,7 @@ def get_amended_article_list(article_list=None, directory=corpusdir):
         article_list = listdir_nohidden(directory)
 
     # check for amendments article type
-    for art in article_list:
+    for art in tqdm(article_list):
         article = Article.from_filename(art)
         article.directory = directory
         if article.amendment:

--- a/allofplos/samples/corpus_analysis.py
+++ b/allofplos/samples/corpus_analysis.py
@@ -10,9 +10,10 @@ examples of analysis. It can:
 import collections
 import csv
 import os
-import progressbar
 import random
 import requests
+
+from tqdm import tqdm
 
 from .. import corpusdir, newarticledir
 
@@ -138,16 +139,12 @@ def get_article_types_map(article_list=None, directory=corpusdir):
     if article_list is None:
         article_list = listdir_nohidden(directory)
     article_types_map = []
-    max_value = len(article_list)
-    bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
-    for i, article_file in enumerate(article_list):
+    for i, article_file in tqdm(article_list):
         article = Article.from_filename(article_file)
         article.directory = directory
         types = [article.type_, article.plostype, article.dtd]
         types = tuple(types)
         article_types_map.append(types)
-        bar.update(i+1)
-    bar.finish()
     return article_types_map
 
 
@@ -251,16 +248,12 @@ def revisiondate_sanity_check(article_list=None, tempdir=newarticledir, director
     except FileExistsError:
         pass
     articles_different_list = []
-    max_value = len(article_list)
-    bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
-    for i, article_file in enumerate(article_list):
+    for article_file in tqdm(article_list):
         updated = download_updated_xml(article_file=article_file)
         if updated:
             articles_different_list.append(article_file)
         if list_provided:
             article_list.remove(article_file)  # helps save time if need to restart process
-        bar.update(i+1)
-    bar.finish()
     print(len(article_list), "article checked for updates.")
     print(len(articles_different_list), "articles have updates.")
     return articles_different_list
@@ -396,14 +389,10 @@ def get_corpus_metadata(article_list=None):
     """
     if article_list is None:
         article_list = listdir_nohidden(corpusdir)
-    max_value = len(article_list)
-    bar = progressbar.ProgressBar(redirect_stdout=True, max_value=max_value)
     corpus_metadata = []
-    for i, article_file in enumerate(article_list):
+    for article_file in tqdm(article_list):
         metadata = get_article_metadata(article_file)
         corpus_metadata.append(metadata)
-        bar.update(i+1)
-    bar.finish()
     return corpus_metadata
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ certifi==2017.7.27.1
 chardet==3.0.4
 idna==2.6
 lxml==4.0.0
-progressbar2==3.34.3
 python-utils==2.2.0
 requests==2.18.4
 six==1.11.0


### PR DESCRIPTION
This PR standardizes progress bars across allofplos and removes `progressbar2` in favor of `tqdm`. `tqdm` requires fewer lines of code, and essentially, only requires wrapping the iterator. Additionally, it plays nicer with print statements that can arise during the iteration and doesn't create a new line for each tick of the progress bar when logging.

Some print statements added/edited for clarity and `progressbar2` removed from `requirements.txt`.