### PR TITLE
add travis yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+ language: python
+ python:
+  - "3.5" 
+  - "3.6"
+  - "nightly"
+ script:
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
  language: python
  python:
+  - "3.4" 
   - "3.5" 
   - "3.6"
-  - "nightly"
  script:
   - pytest


### PR DESCRIPTION
closes #43.

barebones implementation that checks Pythons 3.4-3.6 and runs pytest.
If we want to implement more features, see https://docs.travis-ci.com/user/languages/python/