### PR TITLE
replace corpusdir with get_corpus_dir function

### DIFF
--- a/allofplos/__init__.py
+++ b/allofplos/__init__.py
@@ -19,7 +19,8 @@ def get_corpus_dir():
     """If you want to set the corpus directory, assign the desired path to 
     ``os.environ['PLOS_CORPUS']``.
     """
-    return os.environ.get("PLOS_CORPUS", "") or corpusdir
+    import os
+    return os.path.expanduser(os.environ.get("PLOS_CORPUS", "")) or corpusdir
 
 del os
 

--- a/allofplos/__init__.py
+++ b/allofplos/__init__.py
@@ -14,8 +14,14 @@ newarticledir = os.path.join(ALLOFPLOS_DIR_PATH, 'new_plos_articles')
 
 # List of uncorrected proof articles to check for updates
 uncorrected_proofs_text_list = os.path.join(ALLOFPLOS_DIR_PATH, 'uncorrected_proofs_list.txt')
-
 del os
+
+def get_corpus_dir():
+    del os
+    import os
+    # this is used to make sure that we have a fresh os.environ object when get_corpus_dir is called
+    return os.environ.get("PLOS_CORPUS", "") or corpusdir
+    
 
 # NB: any packages that you want to expose at the top level, you will need to
 # import after creating global variables that they may rely upon

--- a/allofplos/__init__.py
+++ b/allofplos/__init__.py
@@ -14,13 +14,15 @@ newarticledir = os.path.join(ALLOFPLOS_DIR_PATH, 'new_plos_articles')
 
 # List of uncorrected proof articles to check for updates
 uncorrected_proofs_text_list = os.path.join(ALLOFPLOS_DIR_PATH, 'uncorrected_proofs_list.txt')
-del os
 
 def get_corpus_dir():
-    del os
-    import os
-    # this is used to make sure that we have a fresh os.environ object when get_corpus_dir is called
+    """If you want to set the corpus directory, assign the desired path to 
+    ``os.environ['PLOS_CORPUS']``.
+    """
     return os.environ.get("PLOS_CORPUS", "") or corpusdir
+
+del os
+
     
 
 # NB: any packages that you want to expose at the top level, you will need to

--- a/allofplos/allofplos_basics.ipynb
+++ b/allofplos/allofplos_basics.ipynb
@@ -426,7 +426,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Get list of every PLOS article you have downloaded: listdir_nohidden(corpusdir)"
+    "## Get list of every PLOS article you have downloaded: listdir_nohidden(get_corpus_dir())"
    ]
   },
   {

--- a/allofplos/article_class.py
+++ b/allofplos/article_class.py
@@ -20,7 +20,7 @@ class Article():
     """The primary object of a PLOS article, initialized by a valid PLOS DOI.
 
     """
-    def __init__(self, doi, directory=corpusdir, plos_network=False):
+    def __init__(self, doi, directory=None, plos_network=False):
         """Creation of an article object.
 
         Usage:
@@ -40,7 +40,10 @@ class Article():
         :type plos_network: bool, optional
         """
         self.doi = doi
-        self.directory = directory
+        if directory:
+            self.directory = directory
+        else:
+            self.directory = get_corpus_dir()
         self.reset_memoized_attrs()
         self.plos_network = plos_network
         self._editor = None

--- a/allofplos/article_class.py
+++ b/allofplos/article_class.py
@@ -7,7 +7,7 @@ import lxml.etree as et
 from lxml import objectify
 import requests
 
-from . import corpusdir
+from . import get_corpus_dir
 
 from .transformations import (filename_to_doi, EXT_URL_TMP, INT_URL_TMP,
                               BASE_URL_ARTICLE_LANDING_PAGE)

--- a/allofplos/makedb.py
+++ b/allofplos/makedb.py
@@ -20,6 +20,10 @@ from playhouse.sqlite_ext import SqliteExtDatabase
 from .transformations import filename_to_doi, convert_country
 from .article_class import Article
 
+
+# TODO: this may need to be updated to take into account the new get_corpus_dir() logic.
+# It is not clear, since this is a relative path from the package how this should work without
+# diving into the code more thoroughly 
 corpusdir = 'allofplos/allofplos_xml'
 
 journal_title_dict = {

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -33,7 +33,7 @@ import lxml.etree as et
 import requests
 from tqdm import tqdm
 
-from . import corpusdir, newarticledir, uncorrected_proofs_text_list
+from . import get_corpus_dir, newarticledir, uncorrected_proofs_text_list
 
 from .plos_regex import validate_doi
 from .transformations import (BASE_URL_API, EXT_URL_TMP, INT_URL_TMP, URL_TMP, filename_to_doi,

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -171,7 +171,7 @@ def get_all_solr_dois():
     return solr_dois
 
 
-def get_dois_needed_list(comparison_list=None, directory=corpusdir):
+def get_dois_needed_list(comparison_list=None, directory=None):
     """
     Takes result of query from get_all_solr_dois and compares to local article directory.
     :param comparison_list: Defaults to creating a full list of local article files.
@@ -180,6 +180,8 @@ def get_dois_needed_list(comparison_list=None, directory=corpusdir):
     """
     if comparison_list is None:
         comparison_list = get_all_solr_dois()
+    if directory is None:
+        directory = get_corpus_dir()
 
     # Transform local files to DOIs
     local_article_list = [filename_to_doi(article) for article in listdir_nohidden(directory, '.xml')]
@@ -268,7 +270,7 @@ def move_articles(source, destination):
         shutil.rmtree(source)
 
 
-def compare_article_pubdate(doi, days=22, directory=corpusdir):
+def compare_article_pubdate(doi, days=22, directory=None):
     """
     Check if an article's publication date was more than 3 weeks ago.
     :param doi: doi of the article
@@ -276,6 +278,8 @@ def compare_article_pubdate(doi, days=22, directory=corpusdir):
     :param directory: directory the article file is located in (defaults to get_corpus_dir())
     :return: boolean for whether the pubdate was older than the days value
     """
+    if directory is None:
+        directory = get_corpus_dir()
     article = Article(doi, directory=directory)
     try:
         pubdate = article.pubdate
@@ -356,7 +360,7 @@ def check_for_amended_articles(directory=newarticledir, article_list=None):
     return amended_article_list
 
 
-def download_amended_articles(directory=corpusdir, tempdir=newarticledir, amended_article_list=None):
+def download_amended_articles(directory=None, tempdir=newarticledir, amended_article_list=None):
     """For a list of articles that have been amended, check if the xml was also updated.
 
     Use with `check_for_amended_articles`
@@ -367,6 +371,8 @@ def download_amended_articles(directory=corpusdir, tempdir=newarticledir, amende
     :param tempdir: where new articles are downloaded to-
     :return: list of DOIs for articles downloaded with new XML versions
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if amended_article_list is None:
         amended_article_list = check_for_amended_articles(directory)
     amended_updated_article_list = []
@@ -379,13 +385,16 @@ def download_amended_articles(directory=corpusdir, tempdir=newarticledir, amende
     return amended_updated_article_list
 
 
-def get_uncorrected_proofs_list(directory=corpusdir):
+def get_uncorrected_proofs_list(directory=None):
     """
     Loads the uncorrected proofs txt file.
     Failing that, creates new txt file from scratch using directory.
     :param directory: Directory containing the article files
     :return: list of DOIs of uncorrected proofs from text list
     """
+    if directory is None:
+        directory = get_corpus_dir()
+        
     try:
         with open(uncorrected_proofs_text_list) as f:
             uncorrected_proofs_list = f.read().splitlines()
@@ -480,7 +489,7 @@ def check_for_vor_updates(uncorrected_list=None):
     return vor_updates_available
 
 
-def download_vor_updates(directory=corpusdir, tempdir=newarticledir,
+def download_vor_updates(directory=None, tempdir=newarticledir,
                          vor_updates_available=None, plos_network=False):
     """
     For existing uncorrected proofs list, check whether a vor is available to download
@@ -492,6 +501,8 @@ def download_vor_updates(directory=corpusdir, tempdir=newarticledir,
     :param vor_updates_available: Partial DOI/filenames of uncorrected articles, default None
     :return: List of articles from uncorrected_list for which new version successfully downloaded
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if vor_updates_available is None:
         vor_updates_available = check_for_vor_updates()
     vor_updated_article_list = []
@@ -578,7 +589,7 @@ def download_check_and_move(article_list, text_list, tempdir, destination,
     move_articles(tempdir, destination)
 
 
-def download_file_from_google_drive(id, filename, destination=corpusdir,
+def download_file_from_google_drive(id, filename, destination=None,
                                     file_size=None):
     """
     General method for downloading from Google Drive.
@@ -590,6 +601,9 @@ def download_file_from_google_drive(id, filename, destination=corpusdir,
     :return: file path to the zip file
     """
     URL = "https://docs.google.com/uc?export=download"
+    
+    if destination is None:
+        destination = get_corpus_dir()
 
     file_path = os.path.join(destination, filename)
     if not os.path.isfile(file_path):
@@ -666,7 +680,7 @@ def get_zip_metadata(method='initial'):
 
 
 def unzip_articles(file_path,
-                   extract_directory=corpusdir,
+                   extract_directory=None,
                    filetype='zip',
                    delete_file=True
                    ):
@@ -678,6 +692,8 @@ def unzip_articles(file_path,
     :param delete_file: whether to delete the compressed archive after extracting articles
     :return: None
     """
+    if extract_directory is None:
+        extract_directory = get_corpus_dir()
     try:
         os.makedirs(extract_directory)
     except OSError as e:
@@ -700,7 +716,7 @@ def unzip_articles(file_path,
         os.remove(file_path)
 
 
-def create_local_plos_corpus(directory=corpusdir, rm_metadata=True):
+def create_local_plos_corpus(directory=None, rm_metadata=True):
     """
     Downloads a fresh copy of the PLOS corpus by:
     1) creating directory if it doesn't exist
@@ -711,6 +727,8 @@ def create_local_plos_corpus(directory=corpusdir, rm_metadata=True):
     :param rm_metadata: COMPLETE HERE
     :return: None
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if os.path.isdir(directory) is False:
         os.mkdir(directory)
         print('Creating folder for article xml')
@@ -721,7 +739,7 @@ def create_local_plos_corpus(directory=corpusdir, rm_metadata=True):
         os.remove(metadata_path)
 
 
-def create_test_plos_corpus(directory=corpusdir):
+def create_test_plos_corpus(directory=None):
     """
     Downloads a copy of 10,000 randomly selected PLOS articles by:
     1) creating directory if it doesn't exist
@@ -730,6 +748,8 @@ def create_test_plos_corpus(directory=corpusdir):
     :param directory: directory where the corpus is to be downloaded and extracted
     :return: None
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if os.path.isdir(directory) is False:
         os.mkdir(directory)
         print('Creating folder for article xml')
@@ -814,7 +834,7 @@ def main():
     download_check_and_move(dois_needed_list,
                             uncorrected_proofs_text_list,
                             tempdir=newarticledir,
-                            destination=corpusdir,
+                            destination=get_corpus_dir(),
                             plos_network=plos_network)
     return None
 

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -729,9 +729,9 @@ def create_local_plos_corpus(directory=None, rm_metadata=True):
     """
     if directory is None:
         directory = get_corpus_dir()
-    if os.path.isdir(directory) is False:
-        os.mkdir(directory)
+    if not os.path.isdir(directory):
         print('Creating folder for article xml')
+    os.makedirs(directory, exist_ok=True)
     zip_date, zip_size, metadata_path = get_zip_metadata()
     zip_path = download_file_from_google_drive(zip_id, local_zip, file_size=zip_size)
     unzip_articles(file_path=zip_path)
@@ -750,9 +750,9 @@ def create_test_plos_corpus(directory=None):
     """
     if directory is None:
         directory = get_corpus_dir()
-    if os.path.isdir(directory) is False:
-        os.mkdir(directory)
+    if not os.path.isdir(directory):
         print('Creating folder for article xml')
+    os.makedirs(directory, exist_ok=True)
     zip_path = download_file_from_google_drive(test_zip_id, local_test_zip)
     unzip_articles(file_path=zip_path, extract_directory=directory)
 

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -273,7 +273,7 @@ def compare_article_pubdate(doi, days=22, directory=corpusdir):
     Check if an article's publication date was more than 3 weeks ago.
     :param doi: doi of the article
     :param days: how long ago to compare the publication date (default 22 days)
-    :param directory: directory the article file is located in (defaults to corpusdir)
+    :param directory: directory the article file is located in (defaults to get_corpus_dir())
     :return: boolean for whether the pubdate was older than the days value
     """
     article = Article(doi, directory=directory)
@@ -585,7 +585,7 @@ def download_file_from_google_drive(id, filename, destination=corpusdir,
     Doesn't require using API or having credentials
     :param id: Google Drive id for file (constant even if filename change)
     :param filename: name of the zip file
-    :param destination: directory where to download the zip file, defaults to corpusdir
+    :param destination: directory where to download the zip file, defaults to get_corpus_dir()
     :param file_size: size of the file being downloaded
     :return: file path to the zip file
     """
@@ -778,6 +778,7 @@ def main():
                         'Used when inside the plos network')
     args = parser.parse_args()
     plos_network = False
+    directory = get_corpus_dir()
     if args.plos:
         URL_TMP = INT_URL_TMP
         plos_network = True
@@ -785,12 +786,12 @@ def main():
         URL_TMP = EXT_URL_TMP
     # Step 0: Initialize first copy of repository
     try:
-        corpus_files = [name for name in os.listdir(corpusdir) if os.path.isfile(
-                        os.path.join(corpusdir, name))]
+        corpus_files = [name for name in os.listdir(directory) if os.path.isfile(
+                        os.path.join(directory, name))]
     except FileNotFoundError:
         corpus_files = []
     if len(corpus_files) < min_files_for_valid_corpus:
-        print('Not enough articles in corpusdir, re-downloading zip file')
+        print('Not enough articles in {}, re-downloading zip file').format(directory)
         # TODO: check if zip file is in top-level directory before downloading
         create_local_plos_corpus()
 

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -379,10 +379,11 @@ def download_amended_articles(directory=corpusdir, tempdir=newarticledir, amende
     return amended_updated_article_list
 
 
-def get_uncorrected_proofs_list():
+def get_uncorrected_proofs_list(directory=corpusdir):
     """
     Loads the uncorrected proofs txt file.
-    Failing that, creates new txt file from scratch using corpusdir.
+    Failing that, creates new txt file from scratch using directory.
+    :param directory: Directory containing the article files
     :return: list of DOIs of uncorrected proofs from text list
     """
     try:
@@ -390,7 +391,7 @@ def get_uncorrected_proofs_list():
             uncorrected_proofs_list = f.read().splitlines()
     except FileNotFoundError:
         print("Creating new text list of uncorrected proofs from scratch.")
-        article_files = listdir_nohidden(corpusdir)
+        article_files = listdir_nohidden(directory)
         uncorrected_proofs_list = []
         for article_file in tqdm(article_files, disable=None):
             article = Article.from_filename(article_file)
@@ -406,7 +407,7 @@ def get_uncorrected_proofs_list():
 def check_for_uncorrected_proofs(directory=newarticledir, text_list=uncorrected_proofs_text_list):
     """
     For a list of articles, check whether they are the 'uncorrected proof' type
-    One of the checks on newly downloaded articles before they're added to corpusdir
+    One of the checks on newly downloaded articles.
     :param text_list: List of DOIs
     :param directory: Directory containing the article files
     :return: all articles that are uncorrected proofs, including from main article directory
@@ -699,19 +700,19 @@ def unzip_articles(file_path,
         os.remove(file_path)
 
 
-def create_local_plos_corpus(corpusdir=corpusdir, rm_metadata=True):
+def create_local_plos_corpus(directory=corpusdir, rm_metadata=True):
     """
     Downloads a fresh copy of the PLOS corpus by:
-    1) creating corpusdir if it doesn't exist
+    1) creating directory if it doesn't exist
     2) downloading metadata about the .zip of all PLOS XML
     2) downloading the zip file (defaults to corpus directory)
     3) extracting the individual XML files into the corpus directory
-    :param corpusdir: directory where the corpus is to be downloaded and extracted
+    :param directory: directory where the corpus is to be downloaded and extracted
     :param rm_metadata: COMPLETE HERE
     :return: None
     """
-    if os.path.isdir(corpusdir) is False:
-        os.mkdir(corpusdir)
+    if os.path.isdir(directory) is False:
+        os.mkdir(directory)
         print('Creating folder for article xml')
     zip_date, zip_size, metadata_path = get_zip_metadata()
     zip_path = download_file_from_google_drive(zip_id, local_zip, file_size=zip_size)
@@ -720,20 +721,20 @@ def create_local_plos_corpus(corpusdir=corpusdir, rm_metadata=True):
         os.remove(metadata_path)
 
 
-def create_test_plos_corpus(corpusdir=corpusdir):
+def create_test_plos_corpus(directory=corpusdir):
     """
     Downloads a copy of 10,000 randomly selected PLOS articles by:
-    1) creating corpusdir if it doesn't exist
+    1) creating directory if it doesn't exist
     2) downloading the zip file (defaults to corpus directory)
     3) extracting the individual XML files into the corpus directory
-    :param corpusdir: directory where the corpus is to be downloaded and extracted
+    :param directory: directory where the corpus is to be downloaded and extracted
     :return: None
     """
-    if os.path.isdir(corpusdir) is False:
-        os.mkdir(corpusdir)
+    if os.path.isdir(directory) is False:
+        os.mkdir(directory)
         print('Creating folder for article xml')
     zip_path = download_file_from_google_drive(test_zip_id, local_test_zip)
-    unzip_articles(file_path=zip_path, extract_directory=corpusdir)
+    unzip_articles(file_path=zip_path, extract_directory=directory)
 
 
 def download_corpus_metadata_files(csv_abstracts=True, csv_no_abstracts=True, sqlitedb=True, destination=None):

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -7,7 +7,6 @@ import os
 
 from . import get_corpus_dir, newarticledir
 
-get_corpus_dir()_regex = re.escape(get_corpus_dir())
 newarticledir_regex = re.escape(newarticledir)
 regex_match_prefix = r"^10\.1371/"
 regex_body_match = (r"((journal\.p[a-zA-Z]{3}\.[\d]{7}$)"

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -5,7 +5,7 @@ The following RegEx pertains to the 7 main PLOS journals and the defunct PLOS Cl
 import re
 import os
 
-from . import corpusdir, newarticledir
+from . import get_corpus_dir, newarticledir
 
 corpusdir_regex = re.escape(corpusdir)
 newarticledir_regex = re.escape(newarticledir)

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -7,7 +7,7 @@ import os
 
 from . import get_corpus_dir, newarticledir
 
-corpusdir_regex = re.escape(corpusdir)
+get_corpus_dir()_regex = re.escape(get_corpus_dir())
 newarticledir_regex = re.escape(newarticledir)
 regex_match_prefix = r"^10\.1371/"
 regex_body_match = (r"((journal\.p[a-zA-Z]{3}\.[\d]{7}$)"

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -44,8 +44,10 @@ def validate_doi(doi):
 
 def validate_filename(filename):
     """
-    For an individual string, tests whether the full string is in a valid article file in corpusdir or newarticledir
-    format or not.
+    For an individual string, tests whether the full string is in a valid article file. This can take two forms.
+    
+    TODO: Officially document these two forms and give them names. Also, Explain the example below.
+    
     Example: 'allofplos_xml/journal.pbio.2000777.xml' is True, but 'allofplos_xml/journal.pbio.20007779.xml' is False
     :filename: A string with a file name
     :return: True if string is in a valid PLOS corpus article format; False if not

--- a/allofplos/samples/corpus_analysis.py
+++ b/allofplos/samples/corpus_analysis.py
@@ -29,13 +29,15 @@ pmcdir = "pmc_articles"
 max_invalid_files_to_print = 100
 
 
-def validate_corpus(directory=corpusdir):
+def validate_corpus(directory=None):
     """
     For every local article file and DOI listed on Solr, validate file names, DOIs, URLs in terms of
     regular expressions.
     Stops checking as soon as encounters problem and prints it
     :return: boolean of whether corpus passed validity checks
     """
+    if directory is None:
+        directory = get_corpus_dir()
     # check DOIs
     plos_dois = get_all_plos_dois()
     plos_valid_dois = [doi for doi in plos_dois if validate_doi(doi)]
@@ -80,7 +82,7 @@ def validate_corpus(directory=corpusdir):
 # These functions are for getting the article types of all PLOS articles.
 
 
-def get_jats_article_type_list(article_list=None, directory=corpusdir):
+def get_jats_article_type_list(article_list=None, directory=None):
     """Makes a list of of all JATS article types in the corpus
 
     Sorts them by frequency of occurrence
@@ -89,6 +91,8 @@ def get_jats_article_type_list(article_list=None, directory=corpusdir):
     :returns: dictionary with each JATS type matched to number of occurrences
     :rtype: dict
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if article_list is None:
         article_list = listdir_nohidden(directory)
 
@@ -103,7 +107,7 @@ def get_jats_article_type_list(article_list=None, directory=corpusdir):
     return article_types_structured
 
 
-def get_plos_article_type_list(article_list=None, directory=corpusdir):
+def get_plos_article_type_list(article_list=None, directory=None):
     """Makes a list of of all internal PLOS article types in the corpus
 
     Sorts them by frequency of occurrence
@@ -112,6 +116,8 @@ def get_plos_article_type_list(article_list=None, directory=corpusdir):
     :returns: dictionary with each PLOS type matched to number of occurrences
     :rtype: dict
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if article_list is None:
         article_list = listdir_nohidden(directory)
 
@@ -126,7 +132,7 @@ def get_plos_article_type_list(article_list=None, directory=corpusdir):
     return PLOS_article_types_structured
 
 
-def get_article_types_map(article_list=None, directory=corpusdir):
+def get_article_types_map(article_list=None, directory=None):
     """Maps the JATS and PLOS article types onto the XML DTD.
 
     Used for comparing how JATS and PLOS article types are assigned
@@ -135,6 +141,8 @@ def get_article_types_map(article_list=None, directory=corpusdir):
     :returns: list of tuples of JATS, PLOS, DTD for each article in the corpus
     :rtype: list
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if article_list is None:
         article_list = listdir_nohidden(directory)
     article_types_map = []
@@ -162,12 +170,14 @@ def article_types_map_to_csv(article_types_map):
 # These functions are for getting retracted articles
 
 
-def get_retracted_doi_list(article_list=None, directory=corpusdir):
+def get_retracted_doi_list(article_list=None, directory=None):
     """
     Scans through articles in a directory to see if they are retraction notifications,
     scans articles that are that type to find DOIs of retracted articles
     :return: tuple of lists of DOIs for retractions articles, and retracted articles
     """
+    if directory is None:
+        directory = get_corpus_dir()
     retractions_doi_list = []
     retracted_doi_list = []
     if article_list is None:
@@ -187,7 +197,7 @@ def get_retracted_doi_list(article_list=None, directory=corpusdir):
     return retractions_doi_list, retracted_doi_list
 
 
-def get_amended_article_list(article_list=None, directory=corpusdir):
+def get_amended_article_list(article_list=None, directory=None):
     """
     Scans through articles in a directory to see if they are amendment notifications,
     scans articles that are that type to find DOI substrings of amended articles
@@ -195,6 +205,8 @@ def get_amended_article_list(article_list=None, directory=corpusdir):
     :param directory: directory where the article file is, default is get_corpus_dir()
     :return: list of DOIs for articles issued a correction
     """
+    if directory is None:
+        directory = get_corpus_dir()
     amendments_article_list = []
     amended_article_list = []
     if article_list is None:
@@ -218,22 +230,26 @@ def get_amended_article_list(article_list=None, directory=corpusdir):
 
 # These functions are for checking for silent XML updates
 
-def create_pubdate_dict(directory=corpusdir):
+def create_pubdate_dict(directory=None):
     """
     For articles in directory, create a dictionary mapping them to their pubdate.
     Used for truncating the revisiondate_sanity_check to more recent articles only
     :param directory: directory of articles
     :return: a dictionary mapping article files to datetime objects of their pubdates
     """
+    if directory is None:
+        directory = get_corpus_dir()
     articles = listdir_nohidden(directory)
     pubdates = {art: Article.from_filename(art).pubdate for art in articles}
     return pubdates
 
 
-def revisiondate_sanity_check(article_list=None, tempdir=newarticledir, directory=corpusdir, truncated=True):
+def revisiondate_sanity_check(article_list=None, tempdir=newarticledir, directory=None, truncated=True):
     """
     :param truncated: if True, restrict articles to only those with pubdates from the last year or two
     """
+    if directory is None:
+        directory = get_corpus_dir()
     list_provided = bool(article_list)
     if article_list is None and truncated is False:
         article_list = listdir_nohidden(directory)
@@ -268,13 +284,15 @@ def check_solr_doi(doi):
     return bool(article_search['response']['numFound'])
 
 
-def get_all_local_dois(directory=corpusdir):
+def get_all_local_dois(directory=None):
     """Get all local DOIs in a corpus directory.
 
     :param directory: directory of articles, defaults to get_corpus_dir()
     :returns: list of DOIs
     :rtype: list
     """
+    if directory is None:
+        directory = get_corpus_dir()
     local_dois = [filename_to_doi(art) for art in listdir_nohidden(directory)]
     return local_dois
 
@@ -303,7 +321,7 @@ def get_all_plos_dois(local_articles=None, solr_articles=None):
     return plos_articles
 
 
-def get_random_list_of_dois(directory=corpusdir, count=100):
+def get_random_list_of_dois(directory=None, count=100):
     '''
     Gets a list of random DOIs. Tries first to construct from local files in
     directory, otherwise tries Solr DOI list as backup.
@@ -311,6 +329,8 @@ def get_random_list_of_dois(directory=corpusdir, count=100):
     :param count: specify how many DOIs are to be returned
     :return: a list of random DOIs for analysis
     '''
+    if directory is None:
+        directory = get_corpus_dir()
     try:
         article_list = listdir_nohidden(directory)
         sample_file_list = random.sample(article_list, count)
@@ -380,7 +400,7 @@ def get_article_metadata(article_file, size='small'):
         return False
 
 
-def get_corpus_metadata(article_list=None, directory=corpusdir):
+def get_corpus_metadata(article_list=None, directory=None):
     """
     Run get_article_metadata() on a list of files, by default every file in directory 
     Includes a progress bar
@@ -390,6 +410,8 @@ def get_corpus_metadata(article_list=None, directory=corpusdir):
     :param article_list: list of articles to run it on
     :return: list of tuples for each article; list of dicts for wrong date orders
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if article_list is None:
         article_list = listdir_nohidden(directory)
     corpus_metadata = []
@@ -403,7 +425,7 @@ def corpus_metadata_to_csv(corpus_metadata=None,
                            article_list=None,
                            wrong_dates=None,
                            csv_file='allofplos_metadata.csv',
-                           directory=corpusdir
+                           directory=None
                            ):
     """
     Convert list of tuples from get_article_metadata to csv
@@ -414,6 +436,8 @@ def corpus_metadata_to_csv(corpus_metadata=None,
     :directory: 
     :return: None
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if corpus_metadata is None:
         corpus_metadata, wrong_dates = get_corpus_metadata(article_list, directory=directory)
     # write main metadata csv file
@@ -446,13 +470,15 @@ def read_corpus_metadata_from_csv(csv_file='allofplos_metadata.csv'):
     return corpus_metadata
 
 
-def update_corpus_metadata_csv(csv_file='allofplos_metadata.csv', comparison_dois=None, directory=corpusdir):
+def update_corpus_metadata_csv(csv_file='allofplos_metadata.csv', comparison_dois=None, directory=None):
     """
     Incrementally update the metadata of PLOS articles in the csv file
     :param csv_file: csv file of data, defaults to 'allofplos_metadata.csv'
     :comparison_dois: list of DOIs to check whether their metadats is included
     return updated corpus metadata
     """
+    if directory is None:
+        directory = get_corpus_dir()
     # Step 1: get metadata and DOI list from existing csv file
     try:
         corpus_metadata = read_corpus_metadata_from_csv(csv_file)

--- a/allofplos/samples/corpus_analysis.py
+++ b/allofplos/samples/corpus_analysis.py
@@ -85,7 +85,7 @@ def get_jats_article_type_list(article_list=None, directory=corpusdir):
 
     Sorts them by frequency of occurrence
     :param article_list: list of articles, defaults to None
-    :param directory: directory of articles, defaults to corpusdir
+    :param directory: directory of articles, defaults to get_corpus_dir()
     :returns: dictionary with each JATS type matched to number of occurrences
     :rtype: dict
     """
@@ -108,7 +108,7 @@ def get_plos_article_type_list(article_list=None, directory=corpusdir):
 
     Sorts them by frequency of occurrence
     :param article_list: list of articles, defaults to None
-    :param directory: directory of articles, defaults to corpusdir
+    :param directory: directory of articles, defaults to get_corpus_dir()
     :returns: dictionary with each PLOS type matched to number of occurrences
     :rtype: dict
     """
@@ -131,7 +131,7 @@ def get_article_types_map(article_list=None, directory=corpusdir):
 
     Used for comparing how JATS and PLOS article types are assigned
     :param article_list: list of articles, defaults to None
-    :param directory: directory of articles, defaults to corpusdir
+    :param directory: directory of articles, defaults to get_corpus_dir()
     :returns: list of tuples of JATS, PLOS, DTD for each article in the corpus
     :rtype: list
     """
@@ -192,7 +192,7 @@ def get_amended_article_list(article_list=None, directory=corpusdir):
     Scans through articles in a directory to see if they are amendment notifications,
     scans articles that are that type to find DOI substrings of amended articles
     :param article: the filename for a single article
-    :param directory: directory where the article file is, default is corpusdir
+    :param directory: directory where the article file is, default is get_corpus_dir()
     :return: list of DOIs for articles issued a correction
     """
     amendments_article_list = []
@@ -271,7 +271,7 @@ def check_solr_doi(doi):
 def get_all_local_dois(directory=corpusdir):
     """Get all local DOIs in a corpus directory.
 
-    :param directory: directory of articles, defaults to corpusdir
+    :param directory: directory of articles, defaults to get_corpus_dir()
     :returns: list of DOIs
     :rtype: list
     """
@@ -307,7 +307,7 @@ def get_random_list_of_dois(directory=corpusdir, count=100):
     '''
     Gets a list of random DOIs. Tries first to construct from local files in
     directory, otherwise tries Solr DOI list as backup.
-    :param directory: defaults to corpusdir
+    :param directory: defaults to get_corpus_dir()
     :param count: specify how many DOIs are to be returned
     :return: a list of random DOIs for analysis
     '''

--- a/allofplos/samples/corpus_analysis.py
+++ b/allofplos/samples/corpus_analysis.py
@@ -15,7 +15,7 @@ import requests
 
 from tqdm import tqdm
 
-from .. import corpusdir, newarticledir
+from .. import get_corpus_dir, newarticledir
 
 from ..plos_regex import (validate_doi, full_doi_regex_match, validate_url, validate_filename)
 from ..transformations import (filename_to_doi, doi_to_url)

--- a/allofplos/seed_data.py
+++ b/allofplos/seed_data.py
@@ -25,7 +25,7 @@ for doi in open('dois.txt'):
     seed_dois.append(doi.replace('\n',''))
 
 for doi in seed_dois:
-    # Copy file from corpusdir
-    article_path = doi_to_path(doi, corpusdir)
+    # Copy file from get_corpus_dir()
+    article_path = doi_to_path(doi, get_corpus_dir())
     file_name = os.path.basename(article_path)
     copyfile(article_path, os.path.join(seed_directory,file_name))

--- a/allofplos/seed_data.py
+++ b/allofplos/seed_data.py
@@ -10,7 +10,7 @@ regular tool.
 import os
 from shutil import copyfile
 
-from . import corpusdir
+from . import get_corpus_dir
 from .transformations import doi_to_path
 
 seed_directory = 'seed_corpus'

--- a/allofplos/tests/test_unittests.py
+++ b/allofplos/tests/test_unittests.py
@@ -3,7 +3,7 @@ import os
 import unittest
 
 from . import TESTDIR, TESTDATADIR
-from .. import Article, corpusdir
+from .. import Article, get_corpus_dir
 
 from ..transformations import (doi_to_path, url_to_path, filename_to_doi, url_to_doi,
                                filename_to_url, doi_to_url, INT_URL_TMP, EXT_URL_TMP)

--- a/allofplos/tests/test_unittests.py
+++ b/allofplos/tests/test_unittests.py
@@ -32,7 +32,7 @@ class TestDOIMethods(unittest.TestCase):
         """
         TODO: What this tests are about!
         """
-        self.assertEqual(os.path.join(corpusdir, example_file), doi_to_path(example_doi), "{0} does not transform to {1}".format(example_doi, example_file))
+        self.assertEqual(os.path.join(get_corpus_dir(), example_file), doi_to_path(example_doi), "{0} does not transform to {1}".format(example_doi, example_file))
         self.assertEqual(example_file2, doi_to_path(example_doi2, ''), "{0} does not transform to {1}".format(example_doi2, example_file2))
         self.assertEqual(example_url2, doi_to_url(example_doi2), "{0} does not transform to {1}".format(example_doi2, example_url2))
         self.assertEqual(example_url, doi_to_url(example_doi), "In doi_to_url, {0} does not transform to {1}".format(example_doi, example_url))

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -35,6 +35,9 @@ def filename_to_url(filename, plos_network=False):
     Example:
     filename_to_url('allofplos_xml/journal.pone.1000001.xml') = \
     'http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001'
+    
+    TODO: directory is neither a parameter that is given nor one that is used.
+    
     :param file: relative path to local XML file in the corpusdir directory
     :param directory: defaults to corpusdir, containing article files
     :return: online location of a PLOS article's XML
@@ -54,6 +57,9 @@ def filename_to_doi(filename):
     Uses regex to make sure it's a file and not a DOI
     Example:
     filename_to_doi('journal.pone.1000001.xml') = '10.1371/journal.pone.1000001'
+    
+    TODO: directory is neither a parameter that is given nor one that is used.
+    
     :param article_file: relative path to local XML file in the corpusdir directory
     :param directory: defaults to corpusdir, containing article files
     :return: full unique identifier for a PLOS article
@@ -77,7 +83,7 @@ def url_to_path(url, directory=corpusdir, plos_network=False):
     'allofplos_xml/journal.pone.1000001.xml'
     :param url: online location of a PLOS article's XML
     :param directory: defaults to corpusdir, containing article files
-    :return: relative path to local XML file in the corpusdir directory
+    :return: relative path to local XML file in the directory
     """
     annot_prefix = 'plos.correction.'
     if url.startswith(annotation_url) or url.startswith(annotation_url_int):

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -30,16 +30,13 @@ BASE_URL_ARTICLE_LANDING_PAGE = 'http://journals.plos.org/plos{}/article?id='
 
 def filename_to_url(filename, plos_network=False):
     """
-    For a local XML file in the get_corpus_dir() directory, transform it to the downloadable URL where its XML resides
+    Transform filename a downloadable URL where its XML resides
     Includes transform for the 'annotation' DOIs
     Example:
     filename_to_url('allofplos_xml/journal.pone.1000001.xml') = \
     'http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001'
     
-    TODO: directory is neither a parameter that is given nor one that is used.
-    
-    :param file: relative path to local XML file in the get_corpus_dir() directory
-    :param directory: defaults to get_corpus_dir(), containing article files
+    :param filename: string representing a filename 
     :return: online location of a PLOS article's XML
     """
     if correction in filename:
@@ -52,16 +49,13 @@ def filename_to_url(filename, plos_network=False):
 
 def filename_to_doi(filename):
     """
-    For a local XML file in the get_corpus_dir() directory, transform it to the article's DOI
-    Includes transform for the 'annotation' DOIs
+    Transform filename into the article's DOI.
+    Includes transform for the 'annotation' DOIs.
     Uses regex to make sure it's a file and not a DOI
     Example:
     filename_to_doi('journal.pone.1000001.xml') = '10.1371/journal.pone.1000001'
     
-    TODO: directory is neither a parameter that is given nor one that is used.
-    
-    :param article_file: relative path to local XML file in the get_corpus_dir() directory
-    :param directory: defaults to get_corpus_dir(), containing article files
+    :param filename: relative path to local XML file in the get_corpus_dir() directory
     :return: full unique identifier for a PLOS article
     """
     if correction in filename and validate_filename(filename):

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -3,7 +3,7 @@
 
 import os
 
-from . import corpusdir
+from . import get_corpus_dir
 
 from .plos_regex import validate_filename, validate_doi
 

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -30,7 +30,7 @@ BASE_URL_ARTICLE_LANDING_PAGE = 'http://journals.plos.org/plos{}/article?id='
 
 def filename_to_url(filename, plos_network=False):
     """
-    For a local XML file in the corpusdir directory, transform it to the downloadable URL where its XML resides
+    For a local XML file in the get_corpus_dir() directory, transform it to the downloadable URL where its XML resides
     Includes transform for the 'annotation' DOIs
     Example:
     filename_to_url('allofplos_xml/journal.pone.1000001.xml') = \
@@ -38,8 +38,8 @@ def filename_to_url(filename, plos_network=False):
     
     TODO: directory is neither a parameter that is given nor one that is used.
     
-    :param file: relative path to local XML file in the corpusdir directory
-    :param directory: defaults to corpusdir, containing article files
+    :param file: relative path to local XML file in the get_corpus_dir() directory
+    :param directory: defaults to get_corpus_dir(), containing article files
     :return: online location of a PLOS article's XML
     """
     if correction in filename:
@@ -52,7 +52,7 @@ def filename_to_url(filename, plos_network=False):
 
 def filename_to_doi(filename):
     """
-    For a local XML file in the corpusdir directory, transform it to the article's DOI
+    For a local XML file in the get_corpus_dir() directory, transform it to the article's DOI
     Includes transform for the 'annotation' DOIs
     Uses regex to make sure it's a file and not a DOI
     Example:
@@ -60,8 +60,8 @@ def filename_to_doi(filename):
     
     TODO: directory is neither a parameter that is given nor one that is used.
     
-    :param article_file: relative path to local XML file in the corpusdir directory
-    :param directory: defaults to corpusdir, containing article files
+    :param article_file: relative path to local XML file in the get_corpus_dir() directory
+    :param directory: defaults to get_corpus_dir(), containing article files
     :return: full unique identifier for a PLOS article
     """
     if correction in filename and validate_filename(filename):
@@ -82,7 +82,7 @@ def url_to_path(url, directory=corpusdir, plos_network=False):
     url_to_path('http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.1000001') = \
     'allofplos_xml/journal.pone.1000001.xml'
     :param url: online location of a PLOS article's XML
-    :param directory: defaults to corpusdir, containing article files
+    :param directory: defaults to get_corpus_dir(), containing article files
     :return: relative path to local XML file in the directory
     """
     annot_prefix = 'plos.correction.'
@@ -135,7 +135,7 @@ def doi_to_path(doi, directory=corpusdir):
     Example:
     doi_to_path('10.1371/journal.pone.1000001') = 'allofplos_xml/journal.pone.1000001.xml'
     :param doi: full unique identifier for a PLOS article
-    :param directory: defaults to corpusdir, containing article files
+    :param directory: defaults to get_corpus_dir(), containing article files
     :return: relative path to local XML file
     """
     if doi.startswith(annotation_doi) and validate_doi(doi):

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -75,7 +75,7 @@ def filename_to_doi(filename):
     return doi
 
 
-def url_to_path(url, directory=corpusdir, plos_network=False):
+def url_to_path(url, directory=None, plos_network=False):
     """
     For a given PLOS URL to an XML file, return the relative path to the local XML file
     Example:
@@ -85,6 +85,8 @@ def url_to_path(url, directory=corpusdir, plos_network=False):
     :param directory: defaults to get_corpus_dir(), containing article files
     :return: relative path to local XML file in the directory
     """
+    if directory is None:
+        directory = get_corpus_dir()
     annot_prefix = 'plos.correction.'
     if url.startswith(annotation_url) or url.startswith(annotation_url_int):
         # NOTE: REDO THIS!
@@ -126,7 +128,7 @@ def doi_to_url(doi, plos_network=False):
     return URL_TMP.format(doi)
 
 
-def doi_to_path(doi, directory=corpusdir):
+def doi_to_path(doi, directory=None):
     """
     For a given PLOS DOI, return the relative path to that local article
     For DOIs that contain the word 'annotation', searches online version of the article xml to extract
@@ -138,6 +140,8 @@ def doi_to_path(doi, directory=corpusdir):
     :param directory: defaults to get_corpus_dir(), containing article files
     :return: relative path to local XML file
     """
+    if directory is None:
+        directory = get_corpus_dir()
     if doi.startswith(annotation_doi) and validate_doi(doi):
         article_file = os.path.join(directory, "plos.correction." + doi.split('/')[-1] + suffix_lower)
     elif validate_doi(doi):


### PR DESCRIPTION
This should make it possible to store the xml_files in a location specified by an environmental variable, specifically `PLOS_CORPUS`

We should probably add docs explaining how to do this. That could be done in this PR or in a later one. I think it might be better to do in a later one after we decide whether it's better to ask people to set it directly in python or to expect them to set it in their environment before running python (which may be tricky for people not used ot the command line).

@eseiver, I would appreciate if you kicked the tires on this so I can iterate. Thx!
