### PR TITLE
Create gdrive.py and fix incomplete zip download recovery

### DIFF
--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -9,15 +9,15 @@ from tqdm import tqdm
 from . import get_corpus_dir
 
 # Variables needed
-zip_id = '0B_JDnoghFeEKLTlJT09IckMwOFk'
-metadata_id = '0B_JDnoghFeEKQUhKWXBOVy1aTlU'
-local_zip = 'allofplos_xml.zip'
-zip_metadata = 'zip_info.txt'
+ZIP_ID = '0B_JDnoghFeEKLTlJT09IckMwOFk'
+METADATA_ID = '0B_JDnoghFeEKQUhKWXBOVy1aTlU'
+LOCAL_ZIP = 'allofplos_xml.zip'
+ZIP_METADATA = 'zip_info.txt'
 time_formatting = "%Y_%b_%d_%Hh%Mm%Ss"
 min_files_for_valid_corpus = 200000
-test_zip_id = '12VomS72LdTI3aYn4cphYAShv13turbX3'
-local_test_zip = 'sample_corpus.zip'
-gdrive_url = "https://docs.google.com/uc?export=download"
+TEST_ZIP_ID = '12VomS72LdTI3aYn4cphYAShv13turbX3'
+LOCAL_TEST_ZIP = 'sample_corpus.zip'
+GDRIVE_URL = "https://docs.google.com/uc?export=download"
 
 
 def download_file_from_google_drive(id, filename, destination=None,
@@ -56,12 +56,12 @@ def download_file_from_google_drive(id, filename, destination=None,
     if not os.path.isfile(file_path):
         session = requests.Session()
 
-        response = session.get(gdrive_url, params={'id': id}, stream=True)
+        response = session.get(GDRIVE_URL, params={'id': id}, stream=True)
         token = get_confirm_token(response)
 
         if token:
             params = {'id': id, 'confirm': token}
-            response = session.get(gdrive_url, params=params, stream=True)
+            response = session.get(GDRIVE_URL, params=params, stream=True)
         save_response_content(response, file_path, file_size=file_size)
     return file_path
 
@@ -90,7 +90,7 @@ def save_response_content(response, download_path, file_size=None):
     """
     CHUNK_SIZE = 32768
     # for downloading zip file
-    if os.path.basename(download_path) == local_zip:
+    if os.path.basename(download_path) == LOCAL_ZIP:
         with open(download_path, "wb") as f:
             size = file_size
             pieces = round(size / CHUNK_SIZE)
@@ -116,7 +116,7 @@ def get_zip_metadata(method='initial'):
     :return: tuple of data about zip file: date zip created, zip size, and location of metadata txt file
     """
     if method == 'initial':
-        metadata_path = download_file_from_google_drive(metadata_id, zip_metadata)
+        metadata_path = download_file_from_google_drive(METADATA_ID, ZIP_METADATA)
     with open(metadata_path) as f:
         zip_stats = f.read().splitlines()
     zip_datestring = zip_stats[0]

--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -119,11 +119,8 @@ def unzip_articles(file_path,
     :param delete_file: whether to delete the compressed archive after extracting articles
     :return: None
     """
-    try:
-        os.makedirs(extract_directory)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+
+    os.makedirs(extract_directory, exist_ok=True)
 
     if filetype == 'zip':
         with zipfile.ZipFile(file_path, "r") as zip_ref:

--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile, BadZipFile
 import requests
 from tqdm import tqdm
 
-from . import corpusdir
+from . import get_corpus_dir
 
 # Variables needed
 zip_id = '0B_JDnoghFeEKLTlJT09IckMwOFk'
@@ -20,17 +20,19 @@ local_test_zip = 'sample_corpus.zip'
 gdrive_url = "https://docs.google.com/uc?export=download"
 
 
-def download_file_from_google_drive(id, filename, destination=corpusdir,
+def download_file_from_google_drive(id, filename, destination=None,
                                     file_size=None):
     """
     General method for downloading from Google Drive.
     Doesn't require using API or having credentials
     :param id: Google Drive id for file (constant even if filename change)
     :param filename: name of the zip file
-    :param destination: directory where to download the zip file, defaults to corpusdir
+    :param destination: directory where to download the zip file, defaults to get_corpus_dir
     :param file_size: size of the file being downloaded
     :return: None
     """
+    if destination is None:
+        destination = get_corpus_dir()
 
     file_path = os.path.join(destination, filename)
     extension = os.path.splitext(file_path)[1]
@@ -124,7 +126,7 @@ def get_zip_metadata(method='initial'):
 
 
 def unzip_articles(file_path,
-                   extract_directory=corpusdir,
+                   extract_directory=None,
                    filetype='zip',
                    delete_file=True
                    ):
@@ -136,6 +138,8 @@ def unzip_articles(file_path,
     :param delete_file: whether to delete the compressed archive after extracting articles
     :return: None
     """
+    if extract_directory is None:
+        extract_directory = get_corpus_dir()
 
     os.makedirs(extract_directory, exist_ok=True)
 

--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -17,6 +17,7 @@ time_formatting = "%Y_%b_%d_%Hh%Mm%Ss"
 min_files_for_valid_corpus = 200000
 test_zip_id = '12VomS72LdTI3aYn4cphYAShv13turbX3'
 local_test_zip = 'sample_corpus.zip'
+gdrive_url = "https://docs.google.com/uc?export=download"
 
 
 def download_file_from_google_drive(id, filename, destination=corpusdir,
@@ -30,19 +31,18 @@ def download_file_from_google_drive(id, filename, destination=corpusdir,
     :param file_size: size of the file being downloaded
     :return: None
     """
-    URL = "https://docs.google.com/uc?export=download"
 
     file_path = os.path.join(destination, filename)
     if not os.path.isfile(file_path):
         session = requests.Session()
 
-        response = session.get(URL, params={'id': id}, stream=True)
+        response = session.get(gdrive_url, params={'id': id}, stream=True)
         token = get_confirm_token(response)
 
         if token:
             params = {'id': id, 'confirm': token}
-            response = session.get(URL, params=params, stream=True)
-            r = requests.get(URL, params=params, stream=True)
+            response = session.get(gdrive_url, params=params, stream=True)
+            r = requests.get(gdrive_url, params=params, stream=True)
         save_response_content(response, file_path, file_size=file_size)
     return file_path
 

--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -1,0 +1,141 @@
+import datetime
+import os
+import tarfile
+import zipfile
+
+import requests
+from tqdm import tqdm
+
+from . import corpusdir
+
+# Variables needed
+zip_id = '0B_JDnoghFeEKLTlJT09IckMwOFk'
+metadata_id = '0B_JDnoghFeEKQUhKWXBOVy1aTlU'
+local_zip = 'allofplos_xml.zip'
+zip_metadata = 'zip_info.txt'
+time_formatting = "%Y_%b_%d_%Hh%Mm%Ss"
+min_files_for_valid_corpus = 200000
+test_zip_id = '12VomS72LdTI3aYn4cphYAShv13turbX3'
+local_test_zip = 'sample_corpus.zip'
+
+
+def download_file_from_google_drive(id, filename, destination=corpusdir,
+                                    file_size=None):
+    """
+    General method for downloading from Google Drive.
+    Doesn't require using API or having credentials
+    :param id: Google Drive id for file (constant even if filename change)
+    :param filename: name of the zip file
+    :param destination: directory where to download the zip file, defaults to corpusdir
+    :param file_size: size of the file being downloaded
+    :return: None
+    """
+    URL = "https://docs.google.com/uc?export=download"
+
+    file_path = os.path.join(destination, filename)
+    if not os.path.isfile(file_path):
+        session = requests.Session()
+
+        response = session.get(URL, params={'id': id}, stream=True)
+        token = get_confirm_token(response)
+
+        if token:
+            params = {'id': id, 'confirm': token}
+            response = session.get(URL, params=params, stream=True)
+            r = requests.get(URL, params=params, stream=True)
+        save_response_content(response, file_path, file_size=file_size)
+    return file_path
+
+
+def get_confirm_token(response):
+    """
+    Part of keep-alive method for downloading large files from Google Drive
+    Discards packets of data that aren't the actual file
+    :param response: session-based google query
+    :return: either datapacket or discard unneeded data
+    """
+    for key, value in response.cookies.items():
+        if key.startswith('download_warning'):
+            return value
+    return None
+
+
+def save_response_content(response, download_path, file_size=None):
+    """
+    Saves the downloaded file parts from Google Drive to local file
+    Includes progress bar for download %
+    :param response: session-based google query
+    :param download_path: path to local zip file
+    :param file_size: size of the file being downloaded
+    :return: None
+    """
+    CHUNK_SIZE = 32768
+    # for downloading zip file
+    if os.path.basename(download_path) == local_zip:
+        with open(download_path, "wb") as f:
+            size = file_size
+            pieces = round(size / CHUNK_SIZE)
+            with tqdm(total=pieces) as pbar:
+                for chunk in response.iter_content(CHUNK_SIZE):
+                    pbar.update(1)
+                    if chunk:  # filter out keep-alive new chunks
+                        f.write(chunk)
+    # for downloading zip metadata text file
+    else:
+        with open(download_path, "wb") as f:
+            for chunk in response.iter_content(CHUNK_SIZE):
+                if chunk:  # filter out keep-alive new chunks
+                    f.write(chunk)
+
+
+def get_zip_metadata(method='initial'):
+    """
+    Gets metadata txt file from Google Drive, that has info about zip file
+    Used to get the file name, as well as byte size for progress bar
+    Includes progress bar for download %
+    :param method: boolean if initializing the PLOS Corpus (defaults to True)
+    :return: tuple of data about zip file: date zip created, zip size, and location of metadata txt file
+    """
+    if method == 'initial':
+        metadata_path = download_file_from_google_drive(metadata_id, zip_metadata)
+    with open(metadata_path) as f:
+        zip_stats = f.read().splitlines()
+    zip_datestring = zip_stats[0]
+    zip_date = datetime.datetime.strptime(zip_datestring, time_formatting)
+    zip_size = int(zip_stats[1])
+    return zip_date, zip_size, metadata_path
+
+
+def unzip_articles(file_path,
+                   extract_directory=corpusdir,
+                   filetype='zip',
+                   delete_file=True
+                   ):
+    """
+    Unzips zip file of all of PLOS article XML to specified directory
+    :param file_path: path to file to be extracted
+    :param extract_directory: directory where articles are copied to
+    :param filetype: whether a 'zip' or 'tar' file (tarball), which use different decompression libraries
+    :param delete_file: whether to delete the compressed archive after extracting articles
+    :return: None
+    """
+    try:
+        os.makedirs(extract_directory)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+    if filetype == 'zip':
+        with zipfile.ZipFile(file_path, "r") as zip_ref:
+            print("Extracting zip file...")
+            zip_ref.extractall(extract_directory)
+            print("Extraction complete.")
+    elif filetype == 'tar':
+        tar = tarfile.open(file_path)
+        print("Extracting tar file...")
+        tar.extractall(path=extract_directory)
+        tar.close()
+        print("Extraction complete.")
+
+    if delete_file:
+        os.remove(file_path)

--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import tarfile
-import zipfile
+from zipfile import ZipFile
 
 import requests
 from tqdm import tqdm
@@ -123,7 +123,7 @@ def unzip_articles(file_path,
     os.makedirs(extract_directory, exist_ok=True)
 
     if filetype == 'zip':
-        with zipfile.ZipFile(file_path, "r") as zip_ref:
+        with ZipFile(file_path, "r") as zip_ref:
             print("Extracting zip file...")
             zip_ref.extractall(extract_directory)
             print("Extraction complete.")

--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -20,21 +20,21 @@ LOCAL_TEST_ZIP = 'sample_corpus.zip'
 GDRIVE_URL = "https://docs.google.com/uc?export=download"
 
 
-def download_file_from_google_drive(id, filename, destination=None,
+def download_file_from_google_drive(id, filename, directory=None,
                                     file_size=None):
     """
     General method for downloading from Google Drive.
     Doesn't require using API or having credentials
     :param id: Google Drive id for file (constant even if filename change)
     :param filename: name of the zip file
-    :param destination: directory where to download the zip file, defaults to get_corpus_dir
+    :param directory: directory where to download the zip file, defaults to get_corpus_dir
     :param file_size: size of the file being downloaded
     :return: None
     """
-    if destination is None:
-        destination = get_corpus_dir()
+    if directory is None:
+        directory = get_corpus_dir()
 
-    file_path = os.path.join(destination, filename)
+    file_path = os.path.join(directory, filename)
     extension = os.path.splitext(file_path)[1]
 
     # check for existing incomplete zip download. Delete if invalid zip.

--- a/allofplos/gdrive.py
+++ b/allofplos/gdrive.py
@@ -141,9 +141,10 @@ def unzip_articles(file_path,
 
     if filetype == 'zip':
         with ZipFile(file_path, "r") as zip_ref:
-            print("Extracting zip file...")
-            zip_ref.extractall(extract_directory)
-            print("Extraction complete.")
+            tqdm.write("Extracting zip file...")
+            for article in tqdm(zip_ref.namelist()):
+                zip_ref.extract(article, path=extract_directory)
+            tqdm.write("Extraction complete.")
     elif filetype == 'tar':
         tar = tarfile.open(file_path)
         print("Extracting tar file...")

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -610,7 +610,7 @@ def create_local_plos_corpus(directory=None, rm_metadata=True):
         print('Creating folder for article xml')
     os.makedirs(directory, exist_ok=True)
     zip_date, zip_size, metadata_path = get_zip_metadata()
-    zip_path = download_file_from_google_drive(zip_id, local_zip, file_size=zip_size)
+    zip_path = download_file_from_google_drive(ZIP_ID, LOCAL_ZIP, file_size=zip_size)
     unzip_articles(file_path=zip_path)
     if rm_metadata:
         os.remove(metadata_path)
@@ -630,7 +630,7 @@ def create_test_plos_corpus(directory=None):
     if not os.path.isdir(directory):
         print('Creating folder for article xml')
     os.makedirs(directory, exist_ok=True)
-    zip_path = download_file_from_google_drive(test_zip_id, local_test_zip)
+    zip_path = download_file_from_google_drive(TEST_ZIP_ID, LOCAL_TEST_ZIP)
     unzip_articles(file_path=zip_path, extract_directory=directory)
 
 

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -625,27 +625,27 @@ def create_test_plos_corpus(directory=None):
     unzip_articles(file_path=zip_path, extract_directory=directory)
 
 
-def download_corpus_metadata_files(csv_abstracts=True, csv_no_abstracts=True, sqlitedb=True, destination=None):
+def download_corpus_metadata_files(csv_abstracts=True, csv_no_abstracts=True, sqlitedb=True, directory=None):
     """Downloads up to three files of metadata generated from the PLOS Corpus XML.
     Includes two csvs and a sqlite database.
     """
-    if destination is None:
-        destination = os.getcwd()
+    if directory is None:
+        directory = os.getcwd()
     if csv_abstracts:
         csv_abstracts_id = '0B_JDnoghFeEKQWlNUUJtY1pIY3c'
         csv_abstracts_file = download_file_from_google_drive(csv_abstracts_id,
                                                              'allofplos_metadata_test.csv',
-                                                             destination=destination)
+                                                             directory=directory)
     if csv_no_abstracts:
         csv_no_abstracts_id = '0B_JDnoghFeEKeEp6S0R2Sm1YcEk'
         csv_no_abstracts_file = download_file_from_google_drive(csv_no_abstracts_id,
                                                                 'allofplos_metadata_no_abstracts_test.csv',
-                                                                destination=destination)
+                                                                directory=directory)
     if sqlitedb:
         sqlitedb_id = '1gcQW7cc6Z9gDBu_vHxghNwQaMkyvVuMC'
         sqlitedb_file = download_file_from_google_drive(sqlitedb_id,
                                                         'ploscorpus_test.db.gz',
-                                                        destination=destination)
+                                                        directory=directory)
         print("Extracting sqlite db...")
         inF = gzip.open(sqlitedb_file, 'rb')
         outF = open('ploscorpus_test.db', 'wb')

--- a/allofplos/plos_corpus.py
+++ b/allofplos/plos_corpus.py
@@ -39,7 +39,8 @@ from .plos_regex import validate_doi
 from .transformations import (BASE_URL_API, EXT_URL_TMP, INT_URL_TMP, URL_TMP, filename_to_doi,
                               doi_to_path)
 from .article_class import Article
-from .gdrive import download_file_from_google_drive, get_zip_metadata, unzip_articles
+from .gdrive import (download_file_from_google_drive, get_zip_metadata, unzip_articles,
+                     ZIP_ID, LOCAL_ZIP, LOCAL_TEST_ZIP, TEST_ZIP_ID, min_files_for_valid_corpus)
 
 help_str = "This program downloads a zip file with all PLOS articles and checks for updates"
 
@@ -57,16 +58,6 @@ EXAMPLE_SEARCH_URL = ('http://api.plos.org/search?q=*%3A*&fq=doc_type%3Afull&fl=
 
 # Starting out list of needed articles as empty
 dois_needed_list = []
-
-# For zip file and google drive
-zip_id = '0B_JDnoghFeEKLTlJT09IckMwOFk'
-metadata_id = '0B_JDnoghFeEKQUhKWXBOVy1aTlU'
-local_zip = 'allofplos_xml.zip'
-zip_metadata = 'zip_info.txt'
-time_formatting = "%Y_%b_%d_%Hh%Mm%Ss"
-min_files_for_valid_corpus = 200000
-test_zip_id = '12VomS72LdTI3aYn4cphYAShv13turbX3'
-local_test_zip = 'sample_corpus.zip'
 
 
 def listdir_nohidden(path, extension='.xml', include_dir=True):

--- a/allofplos/plos_regex.py
+++ b/allofplos/plos_regex.py
@@ -24,12 +24,12 @@ full_doi_regex_search = re.compile(r"10\.1371/journal\.p[a-zA-Z]{3}\.[\d]{7}"
                                    "|10\.1371/annotation/[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}")
 currents_doi_regex = re.compile(regex_match_prefix+regex_body_currents)
 file_regex_match = re.compile(regex_file_search+r"\.xml")
-base_url = 'http://journals.plos.org/plosone/article/file?id='
-url_suffix = '&type=manuscript'
-external_url_regex_match = re.compile(re.escape(base_url) +
+BASE_URL = 'http://journals.plos.org/plosone/article/file?id='
+URL_SUFFIX = '&type=manuscript'
+external_url_regex_match = re.compile(re.escape(BASE_URL) +
                                       re.escape("10.1371/") +
                                       regex_body_search +
-                                      re.escape(url_suffix))
+                                      re.escape(URL_SUFFIX))
 
 
 def validate_doi(doi):

--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -16,15 +16,15 @@ INT_URL_TMP = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-prod-repo?ke
 URL_TMP = EXT_URL_TMP
 
 BASE_URL_DOI = 'https://doi.org/'
-url_suffix = '&type=manuscript'
+URL_SUFFIX = '&type=manuscript'
 INT_URL_SUFFIX = '.XML'
-prefix = '10.1371/'
-suffix_lower = '.xml'
+PREFIX = '10.1371/'
+SUFFIX_LOWER = '.xml'
 annotation = 'annotation'
 correction = 'correction'
-annotation_url = 'http://journals.plos.org/plosone/article/file?id=10.1371/annotation/'
+ANNOTATION_URL = 'http://journals.plos.org/plosone/article/file?id=10.1371/annotation/'
 annotation_url_int = 'http://contentrepo.plos.org:8002/v1/objects/mogilefs-prod-repo?key=10.1371/annotation/'
-annotation_doi = '10.1371/annotation'
+ANNOTATION_DOI = '10.1371/annotation'
 BASE_URL_ARTICLE_LANDING_PAGE = 'http://journals.plos.org/plos{}/article?id='
 
 
@@ -43,7 +43,7 @@ def filename_to_url(filename, plos_network=False):
         article = 'annotation/' + (filename.split('.', 4)[2])
     else:
         article = os.path.splitext((os.path.basename(filename)))[0]
-    doi = prefix + article
+    doi = PREFIX + article
     return doi_to_url(doi, plos_network)
 
 
@@ -60,9 +60,9 @@ def filename_to_doi(filename):
     """
     if correction in filename and validate_filename(filename):
         article = 'annotation/' + (filename.split('.', 4)[2])
-        doi = prefix + article
+        doi = PREFIX + article
     elif validate_filename(filename):
-        doi = prefix + os.path.splitext((os.path.basename(filename)))[0]
+        doi = PREFIX + os.path.splitext((os.path.basename(filename)))[0]
     # NOTE: A filename should never validate as a DOI, so the next elif is wrong.
     elif validate_doi(filename):
         doi = filename
@@ -82,17 +82,17 @@ def url_to_path(url, directory=None, plos_network=False):
     if directory is None:
         directory = get_corpus_dir()
     annot_prefix = 'plos.correction.'
-    if url.startswith(annotation_url) or url.startswith(annotation_url_int):
+    if url.startswith(ANNOTATION_URL) or url.startswith(annotation_url_int):
         # NOTE: REDO THIS!
         file_ = os.path.join(directory,
                              annot_prefix +
-                             url[url.index(annotation_doi + '/')+len(annotation_doi + '/'):].
-                             replace(url_suffix, '').
+                             url[url.index(ANNOTATION_DOI + '/')+len(ANNOTATION_DOI + '/'):].
+                             replace(URL_SUFFIX, '').
                              replace(INT_URL_SUFFIX, '') + '.xml')
     else:
         file_ = os.path.join(directory,
-                             url[url.index(prefix)+len(prefix):].
-                             replace(url_suffix, '').
+                             url[url.index(PREFIX)+len(PREFIX):].
+                             replace(URL_SUFFIX, '').
                              replace(INT_URL_SUFFIX, '') + '.xml')
     return file_
 
@@ -106,7 +106,7 @@ def url_to_doi(url):
     :param url: online location of a PLOS article's XML
     :return: full unique identifier for a PLOS article
     """
-    return url[url.index(prefix):].rstrip(url_suffix).rstrip(INT_URL_SUFFIX)
+    return url[url.index(PREFIX):].rstrip(URL_SUFFIX).rstrip(INT_URL_SUFFIX)
 
 
 def doi_to_url(doi, plos_network=False):
@@ -136,10 +136,10 @@ def doi_to_path(doi, directory=None):
     """
     if directory is None:
         directory = get_corpus_dir()
-    if doi.startswith(annotation_doi) and validate_doi(doi):
-        article_file = os.path.join(directory, "plos.correction." + doi.split('/')[-1] + suffix_lower)
+    if doi.startswith(ANNOTATION_DOI) and validate_doi(doi):
+        article_file = os.path.join(directory, "plos.correction." + doi.split('/')[-1] + SUFFIX_LOWER)
     elif validate_doi(doi):
-        article_file = os.path.join(directory, doi.lstrip(prefix) + suffix_lower)
+        article_file = os.path.join(directory, doi.lstrip(PREFIX) + SUFFIX_LOWER)
     # NOTE: The following check is weird, a DOI should never validate as a file name.
     elif validate_filename(doi):
         article_file = doi


### PR DESCRIPTION
This closes #47.

This fix was buried in the corpus_class branch and accidentally was never applied to master. Two main things:
– Google Drive functionality is moved over to a new file, `gdrive.py`
– zipfile checks that the allofplos xml zip is valid before extracting. if not (i.e. the download was interrupted), it's deleted and the download is started over.

Also now a download bar for the extraction process, which takes some time. Confirmed working as expected and successfully downloaded corpus from scratch, even after interrupting the zip download.