### PR TITLE
Neater elements

### DIFF
--- a/allofplos/article_class.py
+++ b/allofplos/article_class.py
@@ -939,7 +939,7 @@ class Article():
             journal = Journal.doi_to_journal(self.doi)
         else:
             journal_meta = self.root.xpath('/article/front/journal-meta')[0]
-            journal = Journal(self.doi, journal_meta).parse_plos_journal()
+            journal = str(Journal(journal_meta))
         return journal
 
     @property

--- a/allofplos/article_class.py
+++ b/allofplos/article_class.py
@@ -1015,12 +1015,11 @@ class Article():
         dates = self.get_dates()
         return dates['updated']
 
+    @property
     def license(self):
         """Return dictionary of CC license information from the license field."""
         permissions = self.root.xpath('/article/front/article-meta/permissions')[0]
-        lic = License(permissions, self.doi)
-
-        return lic.license()
+        return dict(License(permissions, self.doi))
 
     @property
     def contributors(self):

--- a/allofplos/elements/journal.py
+++ b/allofplos/elements/journal.py
@@ -4,9 +4,8 @@ from collections import OrderedDict
 class Journal():
     """For parsing the journal name element of articles, as well as converting DOIs to journal names."""
 
-    def __init__(self, doi, journal_meta_element):
+    def __init__(self, journal_meta_element):
         """Initialize an instance of the journal class."""
-        self.doi = doi
         self.element = journal_meta_element
 
     @staticmethod
@@ -29,6 +28,9 @@ class Journal():
                                   ])
 
         return next(value for key, value in journal_map.items() if key in doi)
+    
+    def __str__(self):
+        return self.parse_plos_journal()
 
     def parse_plos_journal(self, caps_fixed=True):
         """For an individual PLOS article, get the journal it was published in from the article XML.

--- a/allofplos/elements/journal.py
+++ b/allofplos/elements/journal.py
@@ -30,6 +30,8 @@ class Journal():
         return next(value for key, value in journal_map.items() if key in doi)
     
     def __str__(self):
+        """Provides str(Journal()) style access to Journal().parse_plos_journal.
+        """
         return self.parse_plos_journal()
 
     def parse_plos_journal(self, caps_fixed=True):

--- a/allofplos/elements/license.py
+++ b/allofplos/elements/license.py
@@ -25,11 +25,18 @@ class License():
         self.doi = doi
     
     def __iter__(self):
+        """Provides the ability to cast License as a dictionary using 
+        dict(License(…)).
+        
+        Returns a generator of (key, value) tuples, which when passed into 
+        dict(), will create the appropriate dictionary. 
+        """
         return ((key, value) for key, value in self.license.items())
     
     @property
     def license(self):
-        """Return dictionary of CC license information from the license field."""
+        """Dictionary of CC license information from the article license field.
+        """
         lic = ''
         cc_link = ''
         copy_year = ''

--- a/allofplos/elements/license.py
+++ b/allofplos/elements/license.py
@@ -23,7 +23,11 @@ class License():
         """Initialize an instance of the license class."""
         self.element = permissions_element
         self.doi = doi
- 
+    
+    def __iter__(self):
+        return ((key, value) for key, value in self.license.items())
+    
+    @property
     def license(self):
         """Return dictionary of CC license information from the license field."""
         lic = ''

--- a/allofplos/tests/test_unittests.py
+++ b/allofplos/tests/test_unittests.py
@@ -105,7 +105,7 @@ class TestArticleClass(unittest.TestCase):
         self.assertEqual(article.url, "http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.0185809&type=manuscript", 'url does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.word_count, 6646, 'word_count does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.taxonomy, {'heading': [('Research Article',)], 'Discipline-v3': [('Biology and life sciences', 'Organisms', 'Eukaryota', 'Animals', 'Invertebrates', 'Arthropoda', 'Insects'), ('Earth sciences', 'Seasons'), ('Earth sciences', 'Geography', 'Human geography', 'Land use'), ('Social sciences', 'Human geography', 'Land use'), ('Biology and life sciences', 'Ecology', 'Ecological metrics', 'Biomass (ecology)'), ('Ecology and environmental sciences', 'Ecology', 'Ecological metrics', 'Biomass (ecology)'), ('Ecology and environmental sciences', 'Conservation science'), ('Biology and life sciences', 'Ecology', 'Plant ecology', 'Plant communities', 'Grasslands'), ('Ecology and environmental sciences', 'Ecology', 'Plant ecology', 'Plant communities', 'Grasslands'), ('Biology and life sciences', 'Plant science', 'Plant ecology', 'Plant communities', 'Grasslands'), ('Ecology and environmental sciences', 'Terrestrial environments', 'Grasslands'), ('Biology and life sciences', 'Ecology', 'Ecological metrics', 'Species diversity'), ('Ecology and environmental sciences', 'Ecology', 'Ecological metrics', 'Species diversity'), ('Biology and life sciences', 'Organisms', 'Eukaryota', 'Plants', 'Herbs')]}, "Taxonomy not retrieved as expected for {0}".format(article.doi))
-        self.assertEqual(article.license(), {'license': 'CC-BY 4.0', 'license_link': 'https://creativecommons.org/licenses/by/4.0/', 'copyright_holder': 'Hallmann et al', 'copyright_year': 2017}, 'license does not transform correctly for {}'.format(article.doi))
+        self.assertEqual(article.license, {'license': 'CC-BY 4.0', 'license_link': 'https://creativecommons.org/licenses/by/4.0/', 'copyright_holder': 'Hallmann et al', 'copyright_year': 2017}, 'license does not transform correctly for {}'.format(article.doi))
 
     def test_example_doi(self):
         """Tests the methods and properties of the Article class
@@ -184,7 +184,7 @@ class TestArticleClass(unittest.TestCase):
         self.assertEqual(article.type_, "retraction", 'type_ does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.url[:100], "http://journals.plos.org/plosone/article/file?id=10.1371/annotation/3155a3e9-5fbe-435c-a07a-e9a4846e", 'url does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.word_count, 129, 'word_count does not transform correctly for {}'.format(article.doi))
-        self.assertEqual(article.license(), {'license': 'CC-BY 4.0', 'license_link': 'https://creativecommons.org/licenses/by/4.0/', 'copyright_holder': '', 'copyright_year': 2012}, 'license does not transform correctly for {}'.format(article.doi))
+        self.assertEqual(article.license, {'license': 'CC-BY 4.0', 'license_link': 'https://creativecommons.org/licenses/by/4.0/', 'copyright_holder': '', 'copyright_year': 2012}, 'license does not transform correctly for {}'.format(article.doi))
 
     def test_proofs(self):
         """Tests whether uncorrected proofs and VOR updates are being detected correctly."""

--- a/allofplos/tests/test_unittests.py
+++ b/allofplos/tests/test_unittests.py
@@ -105,6 +105,7 @@ class TestArticleClass(unittest.TestCase):
         self.assertEqual(article.url, "http://journals.plos.org/plosone/article/file?id=10.1371/journal.pone.0185809&type=manuscript", 'url does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.word_count, 6646, 'word_count does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.taxonomy, {'heading': [('Research Article',)], 'Discipline-v3': [('Biology and life sciences', 'Organisms', 'Eukaryota', 'Animals', 'Invertebrates', 'Arthropoda', 'Insects'), ('Earth sciences', 'Seasons'), ('Earth sciences', 'Geography', 'Human geography', 'Land use'), ('Social sciences', 'Human geography', 'Land use'), ('Biology and life sciences', 'Ecology', 'Ecological metrics', 'Biomass (ecology)'), ('Ecology and environmental sciences', 'Ecology', 'Ecological metrics', 'Biomass (ecology)'), ('Ecology and environmental sciences', 'Conservation science'), ('Biology and life sciences', 'Ecology', 'Plant ecology', 'Plant communities', 'Grasslands'), ('Ecology and environmental sciences', 'Ecology', 'Plant ecology', 'Plant communities', 'Grasslands'), ('Biology and life sciences', 'Plant science', 'Plant ecology', 'Plant communities', 'Grasslands'), ('Ecology and environmental sciences', 'Terrestrial environments', 'Grasslands'), ('Biology and life sciences', 'Ecology', 'Ecological metrics', 'Species diversity'), ('Ecology and environmental sciences', 'Ecology', 'Ecological metrics', 'Species diversity'), ('Biology and life sciences', 'Organisms', 'Eukaryota', 'Plants', 'Herbs')]}, "Taxonomy not retrieved as expected for {0}".format(article.doi))
+        self.assertEqual(article.license(), {'license': 'CC-BY 4.0', 'license_link': 'https://creativecommons.org/licenses/by/4.0/', 'copyright_holder': 'Hallmann et al', 'copyright_year': 2017}, 'license does not transform correctly for {}'.format(article.doi))
 
     def test_example_doi(self):
         """Tests the methods and properties of the Article class
@@ -183,6 +184,7 @@ class TestArticleClass(unittest.TestCase):
         self.assertEqual(article.type_, "retraction", 'type_ does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.url[:100], "http://journals.plos.org/plosone/article/file?id=10.1371/annotation/3155a3e9-5fbe-435c-a07a-e9a4846e", 'url does not transform correctly for {}'.format(article.doi))
         self.assertEqual(article.word_count, 129, 'word_count does not transform correctly for {}'.format(article.doi))
+        self.assertEqual(article.license(), {'license': 'CC-BY 4.0', 'license_link': 'https://creativecommons.org/licenses/by/4.0/', 'copyright_holder': '', 'copyright_year': 2012}, 'license does not transform correctly for {}'.format(article.doi))
 
     def test_proofs(self):
         """Tests whether uncorrected proofs and VOR updates are being detected correctly."""


### PR DESCRIPTION
Small changes to the classes introduced in #81 by @eseiver for cleaner APIs.

- adds unittests for license
- removes unused doi from Journal 
- adds`__str__` for Journal
- provides property access to `License.license` and `Article.license`.
- creates `__iter__` method for a generator that can be used by
`dict(License())`
- amends tests accordingly
