### PR TITLE
Extras require

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,23 +94,29 @@ Here’s what the print statements might look like on a typical run:
 How to run the tests
 --------------------
 
-If you have pytest installed, from anywhere in the allofplos directory, run:
+To run the tests, you will need to install allofplos with its testing
+dependencies. These testing dependencies include ``pytest``, which we will use
+to run the tests.
 
-``(allofplos)$ pytest``
+To get all of the allofplos testing dependencies run:
 
-If you do not have pytest installed, from the top-level project directory, run:
+``(allofplos)$ pip install -U allofplos[test]``
 
-``(allofplos)$ python -m allofplos.tests.test_unittests``
+Then when you run: 
 
-Should return something like this:
+``(allofplos)$ pytest --pyargs allofplos``
 
-::
+It should return something like this:
 
-      ........
-      ----------------------------------------------------------------------
-      Ran 8 tests in 0.257s
+.. code::
+  
+  collected 20 items
 
-      OK
+  allofplos/tests/test_corpus.py ............                       [ 60%]
+  allofplos/tests/test_unittests.py ........                        [100%]
+
+  ==================== 20 passed in 0.36 seconds =========================
+
 
 Community guidelines
 --------------------

--- a/contributing.rst
+++ b/contributing.rst
@@ -13,6 +13,27 @@ Provided that you are in the allofplos directory, install it with::
 
     pip install -U -e .
 
+How to run the tests
+--------------------
+
+``allofplos`` uses ``pytest`` to run its tests. Run ``pip install -e .[test]``
+from the top level of the directory, this will install pytest as well as any
+other testing dependencies.
+
+Once you have ``pytest`` installed, from inside the allofplos directory, run:
+
+``(allofplos)$ pytest``
+
+It should return something like:
+
+.. code::
+  
+  collected 20 items
+
+  allofplos/tests/test_corpus.py ............                       [ 60%]
+  allofplos/tests/test_unittests.py ........                        [100%]
+
+  ==================== 20 passed in 0.36 seconds =========================
 
 Thing to check before doing a release
 -------------------------------------
@@ -24,7 +45,8 @@ Thing to check before doing a release
 Making a release
 ----------------
 Remove untracked files::
-	git clean -xfdi
+  
+    git clean -xfdi
 
 Delete previous packages from dist directory::
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,12 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+
+extras_require = {
+    'test': ['pytest>=3.4.2'], 
+}
+extras_require['all'] = sum(extras_require.values(), [])
+
 setup(
     name='allofplos',
     # https://packaging.python.org/en/latest/single_source_version.html
@@ -50,6 +56,7 @@ setup(
         'urllib3>=1.22',
         'unidecode>=0.04.21',
         ],
+    extras_require = extras_require,
     python_requires='>=3.4',
     # If there are data files included in your packages that need to be
     # installed, specify them here.  If using Python 2.6 or less, then these


### PR DESCRIPTION
@eseiver Pointed out that we didn't have pytest as a testing requirement previously… this fixes that and makes it optional by using extras_require.

This also updates the README and the contributing.rst to explain how to test allofplos in either a standard or an editable install case.