### PR TITLE
fix url structure for clinical trials

### DIFF
--- a/allofplos/transformations.py
+++ b/allofplos/transformations.py
@@ -53,7 +53,7 @@ def _get_base_page(journal):
                    'PLOS Pathogens': 'pathogens',
                    'PLOS Biology': 'biology',
                    'PLOS Medicine': 'medicine',
-                   'PLOS Clinical Trials': 'ctr',
+                   'PLOS Clinical Trials': 'clinicaltrials',
                    }
     try:
         url = BASE_URL_LANDING_PAGE.format(journal_map[journal])


### PR DESCRIPTION
PLOS clinical trials URLs weren't being created correctly; updated URL structure and verified works with:
```
corpus = Corpus()
article = corpus['10.1371/journal.pctr.0010033']
article.open_in_browser()
```