### PR TITLE
Journal fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 allofplos_xml/
 *.zip
+*.DS_Store
 *.log
 .ipynb_checkpoints/*
 *.nxml

--- a/allofplos/elements/journal.py
+++ b/allofplos/elements/journal.py
@@ -1,5 +1,17 @@
 from collections import OrderedDict
 
+journal_map = OrderedDict([
+                         ('pone', 'PLOS ONE'),
+                         ('pcbi', 'PLOS Computational Biology'),
+                         ('pntd', 'PLOS Neglected Tropical Diseases'),
+                         ('pgen', 'PLOS Genetics'),
+                         ('ppat', 'PLOS Pathogens'),
+                         ('pbio', 'PLOS Biology'),
+                         ('pmed', 'PLOS Medicine'),
+                         ('pctr', 'PLOS Clinical Trials'),
+                         ('annotation', 'PLOS ONE')
+                          ])
+
 
 class Journal():
     """For parsing the journal name element of articles, as well as converting DOIs to journal names."""
@@ -15,20 +27,9 @@ class Journal():
         For the subset of DOIs with 'annotation' in the name, assumes PLOS ONE.
         :return: string of journal name
         """
-        journal_map = OrderedDict([
-                                   ('pone', 'PLOS ONE'),
-                                   ('pcbi', 'PLOS Computational Biology'),
-                                   ('pntd', 'PLOS Neglected Tropical Diseases'),
-                                   ('pgen', 'PLOS Genetics'),
-                                   ('ppat', 'PLOS Pathogens'),
-                                   ('pbio', 'PLOS Biology'),
-                                   ('pmed', 'PLOS Medicine'),
-                                   ('pctr', 'PLOS Clinical Trials'),
-                                   ('annotation', 'PLOS ONE')
-                                  ])
 
         return next(value for key, value in journal_map.items() if key in doi)
-    
+
     def __str__(self):
         """Provides str(Journal()) style access to Journal().parse_plos_journal.
         """
@@ -65,4 +66,6 @@ class Journal():
             if journal[0].lower() == 'plos':
                 journal[0] = "PLOS"
             journal = (' ').join(journal)
+
+        assert journal in journal_map.values(), '{}: journal field not a valid PLOS journal'.format(journal)
         return journal

--- a/allofplos/elements/journal.py
+++ b/allofplos/elements/journal.py
@@ -12,6 +12,16 @@ journal_map = OrderedDict([
                          ('annotation', 'PLOS ONE')
                           ])
 
+nlm_ta_journal = {'plos negl trop dis': 'PLOS Neglected Tropical Diseases',
+                  'plos pathog': 'PLOS Pathogens',
+                  'plos genet': 'PLOS Genetics',
+                  'plos biol': 'PLOS Biology',
+                  'plos med': 'PLOS Medicine',
+                  'plos medicin': 'PLOS Medicine',
+                  'plos one': 'PLOS ONE',
+                  'plos comput biol': 'PLOS Computational Biology',
+                 }
+
 
 class Journal():
     """For parsing the journal name element of articles, as well as converting DOIs to journal names."""
@@ -60,6 +70,7 @@ class Journal():
                 nlm_ta_id = [j for j in self.element.getchildren() if j.attrib.get('journal-id-type', None) == 'nlm-ta']
                 assert len(nlm_ta_id) == 1
                 journal = nlm_ta_id[0].text
+                journal = nlm_ta_journal.get(journal.lower(), journal)
 
         if caps_fixed:
             journal = journal.split()

--- a/allofplos/elements/journal.py
+++ b/allofplos/elements/journal.py
@@ -44,13 +44,13 @@ class Journal():
         """
         journal = ''
         # location for newer journal articles
-        journal_path_1 = self.element.xpath('/journal-title-group/journal-title')
+        journal_path_1 = self.element.xpath('./journal-title-group/journal-title')
         if len(journal_path_1):
             assert len(journal_path_1) == 1
             journal = journal_path_1[0].text
         else:
             # location for older journal articles
-            journal_path_2 = self.element.xpath('/journal-title')
+            journal_path_2 = self.element.xpath('./journal-title')
             if len(journal_path_2):
                 assert len(journal_path_2) == 1
                 journal = journal_path_2[0].text


### PR DESCRIPTION
Some fixes in `journal.py`, including:
– fixing XPath query
– standardizing the nlm_ta journal name using `nlm_ta_journal` dictionary
– adding assert statement to make sure valid journal
This means that whenever someone gets journal name from XML instead of the DOI, they can still rest assured it will be standardized. Validated this for the entire corpus.
Also added .DS_Store to .gitignore, coulda sworn it was there already