### PR TITLE
Database scripts

### DIFF
--- a/allofplos/dbtoorm.py
+++ b/allofplos/dbtoorm.py
@@ -43,11 +43,11 @@ class Journal(BaseModel):
 
 class Plosarticle(BaseModel):
     doi = TextField(db_column='DOI', unique=True)
-    jats_type = ForeignKeyField(db_column='JATS_type_id', rel_model=Jatstype, to_field='id')
+    jats_type = ForeignKeyField(column_name='JATS_type_id', model=Jatstype, field='id')
     abstract = TextField()
     created_date = DateTimeField()
-    journal = ForeignKeyField(db_column='journal_id', rel_model=Journal, to_field='id')
-    plostype = ForeignKeyField(db_column='plostype_id', rel_model=Articletype, to_field='id')
+    journal = ForeignKeyField(column_name='journal_id', model=Journal, field='id')
+    plostype = ForeignKeyField(column_name='plostype_id', model=Articletype, field='id')
     title = TextField()
     word_count = IntegerField()
 
@@ -61,9 +61,9 @@ class Country(BaseModel):
         db_table = 'country'
 
 class Correspondingauthor(BaseModel):
-    affiliation = ForeignKeyField(db_column='affiliation_id', rel_model=Affiliations, to_field='id')
+    affiliation = ForeignKeyField(column_name='affiliation_id', model=Affiliations, field='id')
     corr_author_email = CharField(unique=True)
-    country = ForeignKeyField(db_column='country_id', rel_model=Country, to_field='id')
+    country = ForeignKeyField(column_name='country_id', model=Country, field='id')
     given_name = TextField(null=True)
     group_name = TextField(null=True)
     surname = TextField(null=True)
@@ -73,8 +73,8 @@ class Correspondingauthor(BaseModel):
         db_table = 'correspondingauthor'
 
 class Coauthorplosarticle(BaseModel):
-    article = ForeignKeyField(db_column='article_id', rel_model=Plosarticle, to_field='id')
-    corr_author = ForeignKeyField(db_column='corr_author_id', rel_model=Correspondingauthor, to_field='id')
+    article = ForeignKeyField(column_name='article_id', model=Plosarticle, field='id')
+    corr_author = ForeignKeyField(column_name='corr_author_id', model=Correspondingauthor, field='id')
 
     class Meta:
         db_table = 'coauthorplosarticle'

--- a/allofplos/makedb.py
+++ b/allofplos/makedb.py
@@ -8,7 +8,7 @@ Make a SQLite DB out of articles XML files
 import argparse
 import datetime
 import os
-import random
+from itertools import islice
 
 from tqdm import tqdm
 import sqlite3
@@ -119,10 +119,10 @@ db.create_tables([Journal, PLOSArticle, ArticleType, CoAuthorPLOSArticle,
 
 
 corpus_dir = starterdir if args.starter else None
-allfiles = Corpus(corpus_dir).files
-files = random.sample(allfiles, args.random) if args.random else allfiles
+all_files = Corpus(corpus_dir)
+num_files = len(all_files) if args.random is None else args.random
 
-for article in tqdm(Corpus(corpus_dir)):
+for article in tqdm(islice(all_files, args.random), total=num_files):
     journal_name = journal_title_dict[article.journal.upper()]
     with db.atomic() as atomic:
         try:

--- a/allofplos/makedb.py
+++ b/allofplos/makedb.py
@@ -17,10 +17,10 @@ from peewee import Model, CharField, ForeignKeyField, TextField, \
     DateTimeField, BooleanField, IntegerField, IntegrityError
 from playhouse.sqlite_ext import SqliteExtDatabase
 
-from .corpus import Corpus
-from .transformations import filename_to_doi, convert_country
-from . import starterdir
-from .article import Article
+from allofplos.corpus import Corpus
+from allofplos.transformations import filename_to_doi, convert_country
+from allofplos import starterdir
+from allofplos.article import Article
 
 journal_title_dict = {
     'PLOS ONE': 'PLOS ONE',

--- a/allofplos/makedb.py
+++ b/allofplos/makedb.py
@@ -122,9 +122,7 @@ corpus_dir = starterdir if args.starter else None
 allfiles = Corpus(corpus_dir).files
 files = random.sample(allfiles, args.random) if args.random else allfiles
 
-for file_ in tqdm(files):
-    doi = filename_to_doi(file_)
-    article = Article(doi)
+for article in tqdm(Corpus(corpus_dir)):
     journal_name = journal_title_dict[article.journal.upper()]
     with db.atomic() as atomic:
         try:
@@ -145,7 +143,7 @@ for file_ in tqdm(files):
             db.rollback()
             j_type = JATSType.get(JATSType.jats_type == article.type_)
     p_art = PLOSArticle.create(
-        DOI = doi,
+        DOI=article.doi,
         journal = journal,
         abstract=article.abstract.replace('\n', '').replace('\t', ''),
         title = article.title.replace('\n', '').replace('\t', ''),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ six==1.11.0
 tqdm==4.17.1
 unidecode==0.04.21
 urllib3==1.22
-peewee==2.10.2
+peewee==3.5.2
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 
 extras_require = {
-    'test': ['pytest>=3.4.2'], 
+    'test': ['pytest>=3.4.2'],
 }
 extras_require['all'] = sum(extras_require.values(), [])
 
@@ -48,7 +48,7 @@ setup(
         'chardet>=3.0.4',
         'idna>=2.6',
         'lxml>=4.0.0',
-        'peewee>=2.10.2',
+        'peewee>=3.5.2',
         'python-utils>=2.2.0',
         'requests>=2.18.4',
         'six>=1.11.0',


### PR DESCRIPTION
- peewee bumped to latest version. It makes sense to fix the breaking changes before adding more database code
- fixed a bug where makedb.py would always use the default xml folder
- I can never get relative imports to work correctly, and they are discouraged in the official style guide, so I changed them to absolute.

peewee probably doesn't require the absolute latest version, but there is no quick way to check what it supports.