### PR TITLE
Fix body() method

### DIFF
--- a/allofplos/article.py
+++ b/allofplos/article.py
@@ -1214,7 +1214,7 @@ class Article:
         :rtype: {str}
         """
 
-        xml_tree = et.parse(self.filename)
+        xml_tree = et.parse(self.filepath)
         root = xml_tree.getroot()
 
         # limit the text to the body section


### PR DESCRIPTION
Fix the article.body method by replacing the `self.filename` argument with `self.filepath`.